### PR TITLE
Refactor/name

### DIFF
--- a/packages/webdoc-parser/src/build-doc.js
+++ b/packages/webdoc-parser/src/build-doc.js
@@ -193,11 +193,11 @@ export default function buildDoc(symbol: Symbol): ?Doc {
   // if (symbol.meta.object)
 
   // @name might come handy
-  if (!symbol.name) {
+  if (!symbol.simpleName) {
     const nameTag = tags.find((tag) => tag.name === "name");
 
     if (nameTag) {
-      symbol.name = nameTag.value;
+      symbol.simpleName = nameTag.value;
     }
   }
 
@@ -205,12 +205,12 @@ export default function buildDoc(symbol: Symbol): ?Doc {
     if (TAG_OVERRIDES.hasOwnProperty(tags[i].name)) {// eslint-disable-line no-prototype-builtins
       const name = tags[i].name;
 
-      if (!options.name && !tags[i].value && !symbol.name) {
+      if (!options.name && !tags[i].value && !symbol.simpleName) {
         continue;
       }
 
       const doc = createDoc(
-        options.name || tags[i].value || symbol.name,
+        options.name || tags[i].value || symbol.simpleName,
         TAG_OVERRIDES[name],
         options,
         symbol);
@@ -237,15 +237,15 @@ export default function buildDoc(symbol: Symbol): ?Doc {
   try {
     validate(options, symbol.meta);
   } catch (e) {
-    console.error(`Validation for ${symbol.name} [${symbol.path.join(".")}] failed!`);
+    console.error(`Validation for ${symbol.simpleName} [${symbol.canonicalName}] failed!`);
     throw e;
   }
 
   mergeWith(options, symbol.meta, (optVal, metaVal) => optVal === undefined ? metaVal : optVal);
 
-  if (symbol.name && symbol.meta && symbol.meta.type) {
+  if (symbol.simpleName && symbol.meta && symbol.meta.type) {
     // This will transform "symbol" into "doc" (a new object is not created)
-    const doc = createDoc(symbol.name, symbol.meta.type, options, symbol);
+    const doc = createDoc(symbol.simpleName, symbol.meta.type, options, symbol);
 
     // Remove properties from Symbol form
     delete doc.comment;
@@ -257,7 +257,8 @@ export default function buildDoc(symbol: Symbol): ?Doc {
 
     return doc;
   } else {
-    console.log(symbol.name + " -<");
+    console.log(symbol.simpleName + " -<");
   }
+
   return null;
 }

--- a/packages/webdoc-parser/src/parse.js
+++ b/packages/webdoc-parser/src/parse.js
@@ -31,7 +31,7 @@ export function registerLanguage(lang: LanguageIntegration): void {
 registerLanguage(langJS);
 registerLanguage(langTS);
 
-function buildSymbolTree(file: string, fileName ?: string = ".js"): Symbol {
+export function buildSymbolTree(file: string, fileName ?: string = ".js"): Symbol {
   const lang = languages[fileName.substring(fileName.lastIndexOf(".") + 1, fileName.length)];
 
   if (!lang) {

--- a/packages/webdoc-parser/src/parse.js
+++ b/packages/webdoc-parser/src/parse.js
@@ -43,7 +43,7 @@ function buildSymbolTree(file: string, fileName ?: string = ".js"): Symbol {
 
 function assemble(symbol: Symbol, root: RootDoc): void {
   // buildDoc will *destroy* everything in symbol, so store things needed beforehand
-  const name = symbol.name;
+  const name = symbol.simpleName;
   const members = symbol.members;
   const parent = symbol.parent;// :Doc (not a symbol because assemble() was called on parent!!!)
 
@@ -60,9 +60,9 @@ function assemble(symbol: Symbol, root: RootDoc): void {
     console.log("^^^ ERR");
   }
 
-  if (parent && parent.name !== "File") {
+  if (parent && parent.simpleName !== "File") {
     addChildDoc(doc, parent);
-  } else if (symbol.name !== "File") {
+  } else if (symbol.simpleName !== "File") {
     addChildDoc(doc, root);
   }
 

--- a/packages/webdoc-parser/src/symbols-babel/build-symbol-tree.js
+++ b/packages/webdoc-parser/src/symbols-babel/build-symbol-tree.js
@@ -73,7 +73,7 @@ export const SymbolUtils = {
 
     //  if (!isVirtual(doc)) {
     doc.parent = scope;
-    doc.canonicalName = parent.canonicalName + "." + doc.simpleName;
+    doc.canonicalName = scope.canonicalName ? scope.canonicalName + "." + doc.simpleName : doc.simpleName;
     doc.path = [...scope.path, doc.simpleName];
     //  } else {
     //    doc.parent = scope;
@@ -142,6 +142,7 @@ export const SymbolUtils = {
       flags: 0,
       path: [],
       comment: "",
+      canonicalName: "",
       parent: null,
       members: [],
       loc: {start: 0, end: 0},
@@ -154,6 +155,7 @@ export const SymbolUtils = {
       simpleName: "",
       flags: 0,
       path: [...scope.path, ""],
+      canonicalName: scope.canonicalName + ".",
       comment,
       parent: scope,
       members: [],
@@ -200,7 +202,6 @@ export default function buildSymbolTree(file: string, plugins: string[]): Symbol
   }
 
   const ancestorStack = [moduleSymbol];
-  let test;
 
   traverse(ast, {
     enter(nodePath: NodePath) {
@@ -345,6 +346,7 @@ function captureSymbols(node: Node, parent: Symbol): ?Symbol {
       nodeSymbol = Object.assign({
         node,
         simpleName: "",
+        canonicalName: parent.canonicalName,
         flags,
         comment: "",
         path: [...parent.path],
@@ -356,6 +358,7 @@ function captureSymbols(node: Node, parent: Symbol): ?Symbol {
           comment,
           parent: parent,
           members: [],
+          canonicalName: parent.canonicalName + "." + simpleName,
           path: [...parent.path, simpleName],
           loc: nodeDoc ? nodeDoc.loc : {},
           options: {

--- a/packages/webdoc-parser/src/types/Symbol.js
+++ b/packages/webdoc-parser/src/types/Symbol.js
@@ -35,7 +35,8 @@ export type SymbolSignature = {
 // documentation comments.
 export type Symbol = {
   node: ?Node,
-  name: string,
+  simpleName: string,
+  canonicalName: string,
   flags: number,
   path: string[],
   comment: string,

--- a/packages/webdoc-parser/test/lang-js.js
+++ b/packages/webdoc-parser/test/lang-js.js
@@ -1,0 +1,27 @@
+const {buildSymbolTree} = require("../lib/parse");
+
+const expect = require("chai").expect;
+
+describe("@webdoc/parser.LanguageIntegration{@lang js}", function() {
+  it("should parse classes correctly", function() {
+    const symtree = buildSymbolTree(`
+      class ClassName {
+        constructor() { }
+
+        classMethod() { }
+        get classProperty() { return 0; }
+        set classProperty(val) { }
+
+        static staticMethod() { }
+        get staticProperty() { return 0; }
+        set staticProperty(val) { }
+      }
+    `);
+
+    expect(symtree.members.length).to.equal(1);
+
+    const symClassName = symtree.members[0];
+
+    expect(symClassName.members.length).to.equal(5);
+  });
+});


### PR DESCRIPTION
webdoc will deprecate name, path in favor of JavaDoc's simpleName, canonicalName. This PR will move towards that by refactoring the symbol-metadata tree parsing step.