### PR TITLE
[Fix]: TS Unknown keyword

### DIFF
--- a/packages/webdoc-parser/src/symbols-babel/extract-metadata.js
+++ b/packages/webdoc-parser/src/symbols-babel/extract-metadata.js
@@ -55,6 +55,7 @@ import {
   isTSTypeQuery,
   isTSTypeReference,
   isTSUndefinedKeyword,
+  isTSUnknownKeyword,
   isTSUnionType,
   isTSVoidKeyword,
   isTypeAnnotation,
@@ -267,6 +268,9 @@ function resolveDataType(type: TSTypeAnnotation | TSType | any): DataType {
     }
     if (isTSUndefinedKeyword(type)) {
       return createSimpleKeywordType("undefined");
+    }
+    if (isTSUnknownKeyword(type)) {
+      return createSimpleKeywordType("unknown");
     }
     if (isTSVoidKeyword(type)) {
       return createSimpleKeywordType("void");


### PR DESCRIPTION
This will prevent warnings from popping up in a typescript codebase with `unknown` types.