### PR TITLE
Multi-package support in @webdoc/cli, @webdoc/parser, @webdoc/default-template!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,7 @@ coverage/
 
 # Example docs
 example/docs/*
-example/next-docs/*
+example/*docs/*
 
 # OS specific configs
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ coverage/
 
 # Example docs
 example/docs/*
+example/next-docs/*
 
 # OS specific configs
 .DS_Store

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,13 +1,12 @@
 dependencies:
-  '@babel/cli': 7.10.5_@babel+core@7.11.4
-  '@babel/core': 7.11.4
+  '@babel/cli': 7.10.5
   '@babel/parser': 7.11.4
-  '@babel/plugin-proposal-class-properties': 7.10.4_@babel+core@7.11.4
-  '@babel/plugin-transform-flow-comments': 7.10.4_@babel+core@7.11.4
-  '@babel/preset-env': 7.11.0_@babel+core@7.11.4
-  '@babel/preset-flow': 7.10.4_@babel+core@7.11.4
-  '@babel/preset-react': 7.10.4_@babel+core@7.11.4
-  '@babel/register': 7.10.5_@babel+core@7.11.4
+  '@babel/plugin-proposal-class-properties': 7.10.4
+  '@babel/plugin-transform-flow-comments': 7.10.4
+  '@babel/preset-env': 7.11.0
+  '@babel/preset-flow': 7.10.4
+  '@babel/preset-react': 7.10.4
+  '@babel/register': 7.10.5
   '@babel/traverse': 7.9.5
   '@babel/types': 7.9.5
   '@material-ui/core': 4.11.0_react-dom@16.13.1+react@16.13.1
@@ -28,7 +27,7 @@ dependencies:
   '@rush-temp/types': 'file:projects/types.tgz'
   '@rushstack/eslint-patch': 1.0.3
   babel-eslint: 10.1.0_eslint@6.8.0
-  babel-loader: 8.1.0_fbab4801791d746d265885e0d19f0bda
+  babel-loader: 8.1.0_webpack@4.44.1
   bluebird: 3.7.2
   catharsis: 0.8.11
   chai: 4.2.0
@@ -51,7 +50,7 @@ dependencies:
   git-branch: 2.0.1
   globby: 11.0.0
   gulp: 4.0.2
-  gulp-babel: 8.0.0_@babel+core@7.11.4
+  gulp-babel: 8.0.0
   gulp-util: 3.0.8
   jsdoc: 3.6.4
   klaw-sync: 6.0.0
@@ -80,6 +79,24 @@ dependencies:
   yargs: 15.3.1
 lockfileVersion: 5.1
 packages:
+  /@babel/cli/7.10.5:
+    dependencies:
+      commander: 4.1.1
+      convert-source-map: 1.7.0
+      fs-readdir-recursive: 1.1.0
+      glob: 7.1.6
+      lodash: 4.17.20
+      make-dir: 2.1.0
+      slash: 2.0.0
+      source-map: 0.5.7
+    dev: false
+    hasBin: true
+    optionalDependencies:
+      chokidar: 2.1.8
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-j9H9qSf3kLdM0Ao3aGPbGZ73mEA9XazuupcS6cDGWuiyAcANoguhP0r2Lx32H5JGw4sSSoHG3x/mxVnHgvOoyA==
   /@babel/cli/7.10.5_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -136,6 +153,29 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-5deljj5HlqRXN+5oJTY7Zs37iH3z3b++KjiKtIsJy1NrjOOVSEaJHEetLBhyu0aQOSNNZ/0IuEAan9GzRuDXHg==
+  /@babel/core/7.11.6:
+    dependencies:
+      '@babel/code-frame': 7.10.4
+      '@babel/generator': 7.11.6
+      '@babel/helper-module-transforms': 7.11.0
+      '@babel/helpers': 7.10.4
+      '@babel/parser': 7.11.5
+      '@babel/template': 7.10.4
+      '@babel/traverse': 7.11.5
+      '@babel/types': 7.11.5
+      convert-source-map: 1.7.0
+      debug: 4.1.1
+      gensync: 1.0.0-beta.1
+      json5: 2.1.3
+      lodash: 4.17.20
+      resolve: 1.17.0
+      semver: 5.7.1
+      source-map: 0.5.7
+    dev: false
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==
   /@babel/generator/7.11.4:
     dependencies:
       '@babel/types': 7.11.0
@@ -144,6 +184,14 @@ packages:
     dev: false
     resolution:
       integrity: sha512-Rn26vueFx0eOoz7iifCN2UHT6rGtnkSGWSoDRIy8jZN3B91PzeSULbswfLoOWuTuAcNwpG/mxy+uCTDnZ9Mp1g==
+  /@babel/generator/7.11.6:
+    dependencies:
+      '@babel/types': 7.11.5
+      jsesc: 2.5.2
+      source-map: 0.5.7
+    dev: false
+    resolution:
+      integrity: sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==
   /@babel/helper-annotate-as-pure/7.10.4:
     dependencies:
       '@babel/types': 7.11.0
@@ -172,6 +220,18 @@ packages:
     dev: false
     resolution:
       integrity: sha512-5nPcIZ7+KKDxT1427oBivl9V9YTal7qk0diccnh7RrcgrT/pGFOjgGw1dgryyx1GvHEpXVfoDF6Ak3rTiWh8Rg==
+  /@babel/helper-compilation-targets/7.10.4:
+    dependencies:
+      '@babel/compat-data': 7.11.0
+      browserslist: 4.14.0
+      invariant: 2.2.4
+      levenary: 1.1.1
+      semver: 5.7.1
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    resolution:
+      integrity: sha512-a3rYhlsGV0UHNDvrtOXBg8/OpfV0OKTkxKPzIplS1zpx7CygDcWWxckxZeDd3gzPzC4kUT0A4nVFDK0wGMh4MQ==
   /@babel/helper-compilation-targets/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/compat-data': 7.11.0
@@ -185,6 +245,19 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-a3rYhlsGV0UHNDvrtOXBg8/OpfV0OKTkxKPzIplS1zpx7CygDcWWxckxZeDd3gzPzC4kUT0A4nVFDK0wGMh4MQ==
+  /@babel/helper-create-class-features-plugin/7.10.5:
+    dependencies:
+      '@babel/helper-function-name': 7.10.4
+      '@babel/helper-member-expression-to-functions': 7.11.0
+      '@babel/helper-optimise-call-expression': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-replace-supers': 7.10.4
+      '@babel/helper-split-export-declaration': 7.11.0
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    resolution:
+      integrity: sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==
   /@babel/helper-create-class-features-plugin/7.10.5_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -199,6 +272,16 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==
+  /@babel/helper-create-regexp-features-plugin/7.10.4:
+    dependencies:
+      '@babel/helper-annotate-as-pure': 7.10.4
+      '@babel/helper-regex': 7.10.5
+      regexpu-core: 4.7.0
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    resolution:
+      integrity: sha512-2/hu58IEPKeoLF45DBwx3XFqsbCXmkdAay4spVr2x0jYgRxrSNp+ePwvSsy9g6YSaNDcKIQVPXk1Ov8S2edk2g==
   /@babel/helper-create-regexp-features-plugin/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -357,6 +440,23 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-MggwidiH+E9j5Sh8pbrX5sJvMcsqS5o+7iB42M9/k0CD63MjYbdP4nhSh7uB5wnv2/RVzTZFTxzF/kIa5mrCqA==
+  /@babel/parser/7.11.5:
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==
+  /@babel/plugin-proposal-async-generator-functions/7.10.5:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-remap-async-to-generator': 7.11.4
+      '@babel/plugin-syntax-async-generators': 7.8.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-cNMCVezQbrRGvXJwm9fu/1sJj9bHdGAgKodZdLqOQIpfoH3raqmRPBM17+lh7CzhiKRRBrGtZL9WcjxSoGYUSg==
   /@babel/plugin-proposal-async-generator-functions/7.10.5_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -368,6 +468,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-cNMCVezQbrRGvXJwm9fu/1sJj9bHdGAgKodZdLqOQIpfoH3raqmRPBM17+lh7CzhiKRRBrGtZL9WcjxSoGYUSg==
+  /@babel/plugin-proposal-class-properties/7.10.4:
+    dependencies:
+      '@babel/helper-create-class-features-plugin': 7.10.5
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==
   /@babel/plugin-proposal-class-properties/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -378,6 +487,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==
+  /@babel/plugin-proposal-dynamic-import/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-dynamic-import': 7.8.3
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-up6oID1LeidOOASNXgv/CFbgBqTuKJ0cJjz6An5tWD+NVBNlp3VNSBxv2ZdU7SYl3NxJC7agAQDApZusV6uFwQ==
   /@babel/plugin-proposal-dynamic-import/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -388,6 +506,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-up6oID1LeidOOASNXgv/CFbgBqTuKJ0cJjz6An5tWD+NVBNlp3VNSBxv2ZdU7SYl3NxJC7agAQDApZusV6uFwQ==
+  /@babel/plugin-proposal-export-namespace-from/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-aNdf0LY6/3WXkhh0Fdb6Zk9j1NMD8ovj3F6r0+3j837Pn1S1PdNtcwJ5EG9WkVPNHPxyJDaxMaAOVq4eki0qbg==
   /@babel/plugin-proposal-export-namespace-from/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -398,6 +525,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-aNdf0LY6/3WXkhh0Fdb6Zk9j1NMD8ovj3F6r0+3j837Pn1S1PdNtcwJ5EG9WkVPNHPxyJDaxMaAOVq4eki0qbg==
+  /@babel/plugin-proposal-json-strings/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-json-strings': 7.8.3
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-fCL7QF0Jo83uy1K0P2YXrfX11tj3lkpN7l4dMv9Y9VkowkhkQDwFHFd8IiwyK5MZjE8UpbgokkgtcReH88Abaw==
   /@babel/plugin-proposal-json-strings/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -408,6 +544,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-fCL7QF0Jo83uy1K0P2YXrfX11tj3lkpN7l4dMv9Y9VkowkhkQDwFHFd8IiwyK5MZjE8UpbgokkgtcReH88Abaw==
+  /@babel/plugin-proposal-logical-assignment-operators/7.11.0:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-/f8p4z+Auz0Uaf+i8Ekf1iM7wUNLcViFUGiPxKeXvxTSl63B875YPiVdUDdem7hREcI0E0kSpEhS8tF5RphK7Q==
   /@babel/plugin-proposal-logical-assignment-operators/7.11.0_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -418,6 +563,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-/f8p4z+Auz0Uaf+i8Ekf1iM7wUNLcViFUGiPxKeXvxTSl63B875YPiVdUDdem7hREcI0E0kSpEhS8tF5RphK7Q==
+  /@babel/plugin-proposal-nullish-coalescing-operator/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-wq5n1M3ZUlHl9sqT2ok1T2/MTt6AXE0e1Lz4WzWBr95LsAZ5qDXe4KnFuauYyEyLiohvXFMdbsOTMyLZs91Zlw==
   /@babel/plugin-proposal-nullish-coalescing-operator/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -428,6 +582,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-wq5n1M3ZUlHl9sqT2ok1T2/MTt6AXE0e1Lz4WzWBr95LsAZ5qDXe4KnFuauYyEyLiohvXFMdbsOTMyLZs91Zlw==
+  /@babel/plugin-proposal-numeric-separator/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-numeric-separator': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-73/G7QoRoeNkLZFxsoCCvlg4ezE4eM+57PnOqgaPOozd5myfj7p0muD1mRVJvbUWbOzD+q3No2bWbaKy+DJ8DA==
   /@babel/plugin-proposal-numeric-separator/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -438,6 +601,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-73/G7QoRoeNkLZFxsoCCvlg4ezE4eM+57PnOqgaPOozd5myfj7p0muD1mRVJvbUWbOzD+q3No2bWbaKy+DJ8DA==
+  /@babel/plugin-proposal-object-rest-spread/7.11.0:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3
+      '@babel/plugin-transform-parameters': 7.10.5
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-wzch41N4yztwoRw0ak+37wxwJM2oiIiy6huGCoqkvSTA9acYWcPfn9Y4aJqmFFJ70KTJUu29f3DQ43uJ9HXzEA==
   /@babel/plugin-proposal-object-rest-spread/7.11.0_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -449,6 +622,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-wzch41N4yztwoRw0ak+37wxwJM2oiIiy6huGCoqkvSTA9acYWcPfn9Y4aJqmFFJ70KTJUu29f3DQ43uJ9HXzEA==
+  /@babel/plugin-proposal-optional-catch-binding/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-LflT6nPh+GK2MnFiKDyLiqSqVHkQnVf7hdoAvyTnnKj9xB3docGRsdPuxp6qqqW19ifK3xgc9U5/FwrSaCNX5g==
   /@babel/plugin-proposal-optional-catch-binding/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -459,6 +641,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-LflT6nPh+GK2MnFiKDyLiqSqVHkQnVf7hdoAvyTnnKj9xB3docGRsdPuxp6qqqW19ifK3xgc9U5/FwrSaCNX5g==
+  /@babel/plugin-proposal-optional-chaining/7.11.0:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-skip-transparent-expression-wrappers': 7.11.0
+      '@babel/plugin-syntax-optional-chaining': 7.8.3
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-v9fZIu3Y8562RRwhm1BbMRxtqZNFmFA2EG+pT2diuU8PT3H6T/KXoZ54KgYisfOFZHV6PfvAiBIZ9Rcz+/JCxA==
   /@babel/plugin-proposal-optional-chaining/7.11.0_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -470,6 +662,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-v9fZIu3Y8562RRwhm1BbMRxtqZNFmFA2EG+pT2diuU8PT3H6T/KXoZ54KgYisfOFZHV6PfvAiBIZ9Rcz+/JCxA==
+  /@babel/plugin-proposal-private-methods/7.10.4:
+    dependencies:
+      '@babel/helper-create-class-features-plugin': 7.10.5
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-wh5GJleuI8k3emgTg5KkJK6kHNsGEr0uBTDBuQUBJwckk9xs1ez79ioheEVVxMLyPscB0LfkbVHslQqIzWV6Bw==
   /@babel/plugin-proposal-private-methods/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -480,6 +681,17 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-wh5GJleuI8k3emgTg5KkJK6kHNsGEr0uBTDBuQUBJwckk9xs1ez79ioheEVVxMLyPscB0LfkbVHslQqIzWV6Bw==
+  /@babel/plugin-proposal-unicode-property-regex/7.10.4:
+    dependencies:
+      '@babel/helper-create-regexp-features-plugin': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    engines:
+      node: '>=4'
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-H+3fOgPnEXFL9zGYtKQe4IDOPKYlZdF1kqFDQRRb8PK4B8af1vAGK04tF5iQAAsui+mHNBQSAtd2/ndEDe9wuA==
   /@babel/plugin-proposal-unicode-property-regex/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -492,6 +704,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-H+3fOgPnEXFL9zGYtKQe4IDOPKYlZdF1kqFDQRRb8PK4B8af1vAGK04tF5iQAAsui+mHNBQSAtd2/ndEDe9wuA==
+  /@babel/plugin-syntax-async-generators/7.8.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -501,6 +721,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
+  /@babel/plugin-syntax-class-properties/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==
   /@babel/plugin-syntax-class-properties/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -510,6 +738,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==
+  /@babel/plugin-syntax-dynamic-import/7.8.3:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
   /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -519,6 +755,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
+  /@babel/plugin-syntax-export-namespace-from/7.8.3:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==
   /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -528,6 +772,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==
+  /@babel/plugin-syntax-flow/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-yxQsX1dJixF4qEEdzVbst3SZQ58Nrooz8NV9Z9GL4byTE25BvJgl5lf0RECUf0fh28rZBb/RYTWn/eeKwCMrZQ==
   /@babel/plugin-syntax-flow/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -537,6 +789,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-yxQsX1dJixF4qEEdzVbst3SZQ58Nrooz8NV9Z9GL4byTE25BvJgl5lf0RECUf0fh28rZBb/RYTWn/eeKwCMrZQ==
+  /@babel/plugin-syntax-json-strings/7.8.3:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
   /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -546,6 +806,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
+  /@babel/plugin-syntax-jsx/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==
   /@babel/plugin-syntax-jsx/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -555,6 +823,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==
+  /@babel/plugin-syntax-logical-assignment-operators/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==
   /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -564,6 +840,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==
+  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -573,6 +857,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
+  /@babel/plugin-syntax-numeric-separator/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==
   /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -582,6 +874,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==
+  /@babel/plugin-syntax-object-rest-spread/7.8.3:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -591,6 +891,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
+  /@babel/plugin-syntax-optional-catch-binding/7.8.3:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
   /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -600,6 +908,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
+  /@babel/plugin-syntax-optional-chaining/7.8.3:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -609,6 +925,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
+  /@babel/plugin-syntax-top-level-await/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-ni1brg4lXEmWyafKr0ccFWkJG0CeMt4WV1oyeBW6EFObF4oOHclbkj5cARxAPQyAQ2UTuplJyK4nfkXIMMFvsQ==
   /@babel/plugin-syntax-top-level-await/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -618,6 +942,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-ni1brg4lXEmWyafKr0ccFWkJG0CeMt4WV1oyeBW6EFObF4oOHclbkj5cARxAPQyAQ2UTuplJyK4nfkXIMMFvsQ==
+  /@babel/plugin-transform-arrow-functions/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-9J/oD1jV0ZCBcgnoFWFq1vJd4msoKb/TCpGNFyyLt0zABdcvgK3aYikZ8HjzB14c26bc7E3Q1yugpwGy2aTPNA==
   /@babel/plugin-transform-arrow-functions/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -627,6 +959,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-9J/oD1jV0ZCBcgnoFWFq1vJd4msoKb/TCpGNFyyLt0zABdcvgK3aYikZ8HjzB14c26bc7E3Q1yugpwGy2aTPNA==
+  /@babel/plugin-transform-async-to-generator/7.10.4:
+    dependencies:
+      '@babel/helper-module-imports': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-remap-async-to-generator': 7.11.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-F6nREOan7J5UXTLsDsZG3DXmZSVofr2tGNwfdrVwkDWHfQckbQXnXSPfD7iO+c/2HGqycwyLST3DnZ16n+cBJQ==
   /@babel/plugin-transform-async-to-generator/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -638,6 +980,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-F6nREOan7J5UXTLsDsZG3DXmZSVofr2tGNwfdrVwkDWHfQckbQXnXSPfD7iO+c/2HGqycwyLST3DnZ16n+cBJQ==
+  /@babel/plugin-transform-block-scoped-functions/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-WzXDarQXYYfjaV1szJvN3AD7rZgZzC1JtjJZ8dMHUyiK8mxPRahynp14zzNjU3VkPqPsO38CzxiWO1c9ARZ8JA==
   /@babel/plugin-transform-block-scoped-functions/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -647,6 +997,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-WzXDarQXYYfjaV1szJvN3AD7rZgZzC1JtjJZ8dMHUyiK8mxPRahynp14zzNjU3VkPqPsO38CzxiWO1c9ARZ8JA==
+  /@babel/plugin-transform-block-scoping/7.11.1:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-00dYeDE0EVEHuuM+26+0w/SCL0BH2Qy7LwHuI4Hi4MH5gkC8/AqMN5uWFJIsoXZrAphiMm1iXzBw6L2T+eA0ew==
   /@babel/plugin-transform-block-scoping/7.11.1_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -656,6 +1014,21 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-00dYeDE0EVEHuuM+26+0w/SCL0BH2Qy7LwHuI4Hi4MH5gkC8/AqMN5uWFJIsoXZrAphiMm1iXzBw6L2T+eA0ew==
+  /@babel/plugin-transform-classes/7.10.4:
+    dependencies:
+      '@babel/helper-annotate-as-pure': 7.10.4
+      '@babel/helper-define-map': 7.10.5
+      '@babel/helper-function-name': 7.10.4
+      '@babel/helper-optimise-call-expression': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-replace-supers': 7.10.4
+      '@babel/helper-split-export-declaration': 7.11.0
+      globals: 11.12.0
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-2oZ9qLjt161dn1ZE0Ms66xBncQH4In8Sqw1YWgBUZuGVJJS5c0OFZXL6dP2MRHrkU/eKhWg8CzFJhRQl50rQxA==
   /@babel/plugin-transform-classes/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -672,6 +1045,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-2oZ9qLjt161dn1ZE0Ms66xBncQH4In8Sqw1YWgBUZuGVJJS5c0OFZXL6dP2MRHrkU/eKhWg8CzFJhRQl50rQxA==
+  /@babel/plugin-transform-computed-properties/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-JFwVDXcP/hM/TbyzGq3l/XWGut7p46Z3QvqFMXTfk6/09m7xZHJUN9xHfsv7vqqD4YnfI5ueYdSJtXqqBLyjBw==
   /@babel/plugin-transform-computed-properties/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -681,6 +1062,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-JFwVDXcP/hM/TbyzGq3l/XWGut7p46Z3QvqFMXTfk6/09m7xZHJUN9xHfsv7vqqD4YnfI5ueYdSJtXqqBLyjBw==
+  /@babel/plugin-transform-destructuring/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==
   /@babel/plugin-transform-destructuring/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -690,6 +1079,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==
+  /@babel/plugin-transform-dotall-regex/7.10.4:
+    dependencies:
+      '@babel/helper-create-regexp-features-plugin': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-ZEAVvUTCMlMFAbASYSVQoxIbHm2OkG2MseW6bV2JjIygOjdVv8tuxrCTzj1+Rynh7ODb8GivUy7dzEXzEhuPaA==
   /@babel/plugin-transform-dotall-regex/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -700,6 +1098,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-ZEAVvUTCMlMFAbASYSVQoxIbHm2OkG2MseW6bV2JjIygOjdVv8tuxrCTzj1+Rynh7ODb8GivUy7dzEXzEhuPaA==
+  /@babel/plugin-transform-duplicate-keys/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-GL0/fJnmgMclHiBTTWXNlYjYsA7rDrtsazHG6mglaGSTh0KsrW04qml+Bbz9FL0LcJIRwBWL5ZqlNHKTkU3xAA==
   /@babel/plugin-transform-duplicate-keys/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -709,6 +1115,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-GL0/fJnmgMclHiBTTWXNlYjYsA7rDrtsazHG6mglaGSTh0KsrW04qml+Bbz9FL0LcJIRwBWL5ZqlNHKTkU3xAA==
+  /@babel/plugin-transform-exponentiation-operator/7.10.4:
+    dependencies:
+      '@babel/helper-builder-binary-assignment-operator-visitor': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-S5HgLVgkBcRdyQAHbKj+7KyuWx8C6t5oETmUuwz1pt3WTWJhsUV0WIIXuVvfXMxl/QQyHKlSCNNtaIamG8fysw==
   /@babel/plugin-transform-exponentiation-operator/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -719,6 +1134,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-S5HgLVgkBcRdyQAHbKj+7KyuWx8C6t5oETmUuwz1pt3WTWJhsUV0WIIXuVvfXMxl/QQyHKlSCNNtaIamG8fysw==
+  /@babel/plugin-transform-flow-comments/7.10.4:
+    dependencies:
+      '@babel/generator': 7.11.4
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-flow': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-wiwS5fCzeWP71WLIzAoFAPTk0GLnhpUfGV4ygwX+Zib6nYiaLhUOWsjLt6+hCwCoH/bwZSg7Qzlc2AuzXg/mbg==
   /@babel/plugin-transform-flow-comments/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -730,6 +1155,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-wiwS5fCzeWP71WLIzAoFAPTk0GLnhpUfGV4ygwX+Zib6nYiaLhUOWsjLt6+hCwCoH/bwZSg7Qzlc2AuzXg/mbg==
+  /@babel/plugin-transform-flow-strip-types/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-flow': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-XTadyuqNst88UWBTdLjM+wEY7BFnY2sYtPyAidfC7M/QaZnSuIZpMvLxqGT7phAcnGyWh/XQFLKcGf04CnvxSQ==
   /@babel/plugin-transform-flow-strip-types/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -740,6 +1174,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-XTadyuqNst88UWBTdLjM+wEY7BFnY2sYtPyAidfC7M/QaZnSuIZpMvLxqGT7phAcnGyWh/XQFLKcGf04CnvxSQ==
+  /@babel/plugin-transform-for-of/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==
   /@babel/plugin-transform-for-of/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -749,6 +1191,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==
+  /@babel/plugin-transform-function-name/7.10.4:
+    dependencies:
+      '@babel/helper-function-name': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-OcDCq2y5+E0dVD5MagT5X+yTRbcvFjDI2ZVAottGH6tzqjx/LKpgkUepu3hp/u4tZBzxxpNGwLsAvGBvQ2mJzg==
   /@babel/plugin-transform-function-name/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -759,6 +1210,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-OcDCq2y5+E0dVD5MagT5X+yTRbcvFjDI2ZVAottGH6tzqjx/LKpgkUepu3hp/u4tZBzxxpNGwLsAvGBvQ2mJzg==
+  /@babel/plugin-transform-literals/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-Xd/dFSTEVuUWnyZiMu76/InZxLTYilOSr1UlHV+p115Z/Le2Fi1KXkJUYz0b42DfndostYlPub3m8ZTQlMaiqQ==
   /@babel/plugin-transform-literals/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -768,6 +1227,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Xd/dFSTEVuUWnyZiMu76/InZxLTYilOSr1UlHV+p115Z/Le2Fi1KXkJUYz0b42DfndostYlPub3m8ZTQlMaiqQ==
+  /@babel/plugin-transform-member-expression-literals/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-0bFOvPyAoTBhtcJLr9VcwZqKmSjFml1iVxvPL0ReomGU53CX53HsM4h2SzckNdkQcHox1bpAqzxBI1Y09LlBSw==
   /@babel/plugin-transform-member-expression-literals/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -777,6 +1244,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-0bFOvPyAoTBhtcJLr9VcwZqKmSjFml1iVxvPL0ReomGU53CX53HsM4h2SzckNdkQcHox1bpAqzxBI1Y09LlBSw==
+  /@babel/plugin-transform-modules-amd/7.10.5:
+    dependencies:
+      '@babel/helper-module-transforms': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+      babel-plugin-dynamic-import-node: 2.3.3
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-elm5uruNio7CTLFItVC/rIzKLfQ17+fX7EVz5W0TMgIHFo1zY0Ozzx+lgwhL4plzl8OzVn6Qasx5DeEFyoNiRw==
   /@babel/plugin-transform-modules-amd/7.10.5_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -788,6 +1265,17 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-elm5uruNio7CTLFItVC/rIzKLfQ17+fX7EVz5W0TMgIHFo1zY0Ozzx+lgwhL4plzl8OzVn6Qasx5DeEFyoNiRw==
+  /@babel/plugin-transform-modules-commonjs/7.10.4:
+    dependencies:
+      '@babel/helper-module-transforms': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-simple-access': 7.10.4
+      babel-plugin-dynamic-import-node: 2.3.3
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-Xj7Uq5o80HDLlW64rVfDBhao6OX89HKUmb+9vWYaLXBZOma4gA6tw4Ni1O5qVDoZWUV0fxMYA0aYzOawz0l+1w==
   /@babel/plugin-transform-modules-commonjs/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -800,6 +1288,17 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Xj7Uq5o80HDLlW64rVfDBhao6OX89HKUmb+9vWYaLXBZOma4gA6tw4Ni1O5qVDoZWUV0fxMYA0aYzOawz0l+1w==
+  /@babel/plugin-transform-modules-systemjs/7.10.5:
+    dependencies:
+      '@babel/helper-hoist-variables': 7.10.4
+      '@babel/helper-module-transforms': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+      babel-plugin-dynamic-import-node: 2.3.3
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-f4RLO/OL14/FP1AEbcsWMzpbUz6tssRaeQg11RH1BP/XnPpRoVwgeYViMFacnkaw4k4wjRSjn3ip1Uw9TaXuMw==
   /@babel/plugin-transform-modules-systemjs/7.10.5_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -812,6 +1311,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-f4RLO/OL14/FP1AEbcsWMzpbUz6tssRaeQg11RH1BP/XnPpRoVwgeYViMFacnkaw4k4wjRSjn3ip1Uw9TaXuMw==
+  /@babel/plugin-transform-modules-umd/7.10.4:
+    dependencies:
+      '@babel/helper-module-transforms': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-mohW5q3uAEt8T45YT7Qc5ws6mWgJAaL/8BfWD9Dodo1A3RKWli8wTS+WiQ/knF+tXlPirW/1/MqzzGfCExKECA==
   /@babel/plugin-transform-modules-umd/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -822,6 +1330,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-mohW5q3uAEt8T45YT7Qc5ws6mWgJAaL/8BfWD9Dodo1A3RKWli8wTS+WiQ/knF+tXlPirW/1/MqzzGfCExKECA==
+  /@babel/plugin-transform-named-capturing-groups-regex/7.10.4:
+    dependencies:
+      '@babel/helper-create-regexp-features-plugin': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    resolution:
+      integrity: sha512-V6LuOnD31kTkxQPhKiVYzYC/Jgdq53irJC/xBSmqcNcqFGV+PER4l6rU5SH2Vl7bH9mLDHcc0+l9HUOe4RNGKA==
   /@babel/plugin-transform-named-capturing-groups-regex/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -831,6 +1347,14 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-V6LuOnD31kTkxQPhKiVYzYC/Jgdq53irJC/xBSmqcNcqFGV+PER4l6rU5SH2Vl7bH9mLDHcc0+l9HUOe4RNGKA==
+  /@babel/plugin-transform-new-target/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-YXwWUDAH/J6dlfwqlWsztI2Puz1NtUAubXhOPLQ5gjR/qmQ5U96DY4FQO8At33JN4XPBhrjB8I4eMmLROjjLjw==
   /@babel/plugin-transform-new-target/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -840,6 +1364,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-YXwWUDAH/J6dlfwqlWsztI2Puz1NtUAubXhOPLQ5gjR/qmQ5U96DY4FQO8At33JN4XPBhrjB8I4eMmLROjjLjw==
+  /@babel/plugin-transform-object-super/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-replace-supers': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-5iTw0JkdRdJvr7sY0vHqTpnruUpTea32JHmq/atIWqsnNussbRzjEDyWep8UNztt1B5IusBYg8Irb0bLbiEBCQ==
   /@babel/plugin-transform-object-super/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -850,6 +1383,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-5iTw0JkdRdJvr7sY0vHqTpnruUpTea32JHmq/atIWqsnNussbRzjEDyWep8UNztt1B5IusBYg8Irb0bLbiEBCQ==
+  /@babel/plugin-transform-parameters/7.10.5:
+    dependencies:
+      '@babel/helper-get-function-arity': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-xPHwUj5RdFV8l1wuYiu5S9fqWGM2DrYc24TMvUiRrPVm+SM3XeqU9BcokQX/kEUe+p2RBwy+yoiR1w/Blq6ubw==
   /@babel/plugin-transform-parameters/7.10.5_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -860,6 +1402,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-xPHwUj5RdFV8l1wuYiu5S9fqWGM2DrYc24TMvUiRrPVm+SM3XeqU9BcokQX/kEUe+p2RBwy+yoiR1w/Blq6ubw==
+  /@babel/plugin-transform-property-literals/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-ofsAcKiUxQ8TY4sScgsGeR2vJIsfrzqvFb9GvJ5UdXDzl+MyYCaBj/FGzXuv7qE0aJcjWMILny1epqelnFlz8g==
   /@babel/plugin-transform-property-literals/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -869,6 +1419,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-ofsAcKiUxQ8TY4sScgsGeR2vJIsfrzqvFb9GvJ5UdXDzl+MyYCaBj/FGzXuv7qE0aJcjWMILny1epqelnFlz8g==
+  /@babel/plugin-transform-react-display-name/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-Zd4X54Mu9SBfPGnEcaGcOrVAYOtjT2on8QZkLKEq1S/tHexG39d9XXGZv19VfRrDjPJzFmPfTAqOQS1pfFOujw==
   /@babel/plugin-transform-react-display-name/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -878,6 +1436,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Zd4X54Mu9SBfPGnEcaGcOrVAYOtjT2on8QZkLKEq1S/tHexG39d9XXGZv19VfRrDjPJzFmPfTAqOQS1pfFOujw==
+  /@babel/plugin-transform-react-jsx-development/7.10.4:
+    dependencies:
+      '@babel/helper-builder-react-jsx-experimental': 7.10.5
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-jsx': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-RM3ZAd1sU1iQ7rI2dhrZRZGv0aqzNQMbkIUCS1txYpi9wHQ2ZHNjo5TwX+UD6pvFW4AbWqLVYvKy5qJSAyRGjQ==
   /@babel/plugin-transform-react-jsx-development/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -889,6 +1457,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-RM3ZAd1sU1iQ7rI2dhrZRZGv0aqzNQMbkIUCS1txYpi9wHQ2ZHNjo5TwX+UD6pvFW4AbWqLVYvKy5qJSAyRGjQ==
+  /@babel/plugin-transform-react-jsx-self/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-jsx': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-yOvxY2pDiVJi0axdTWHSMi5T0DILN+H+SaeJeACHKjQLezEzhLx9nEF9xgpBLPtkZsks9cnb5P9iBEi21En3gg==
   /@babel/plugin-transform-react-jsx-self/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -899,6 +1476,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-yOvxY2pDiVJi0axdTWHSMi5T0DILN+H+SaeJeACHKjQLezEzhLx9nEF9xgpBLPtkZsks9cnb5P9iBEi21En3gg==
+  /@babel/plugin-transform-react-jsx-source/7.10.5:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-jsx': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-wTeqHVkN1lfPLubRiZH3o73f4rfon42HpgxUSs86Nc+8QIcm/B9s8NNVXu/gwGcOyd7yDib9ikxoDLxJP0UiDA==
   /@babel/plugin-transform-react-jsx-source/7.10.5_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -909,6 +1495,17 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-wTeqHVkN1lfPLubRiZH3o73f4rfon42HpgxUSs86Nc+8QIcm/B9s8NNVXu/gwGcOyd7yDib9ikxoDLxJP0UiDA==
+  /@babel/plugin-transform-react-jsx/7.10.4:
+    dependencies:
+      '@babel/helper-builder-react-jsx': 7.10.4
+      '@babel/helper-builder-react-jsx-experimental': 7.10.5
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-jsx': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-L+MfRhWjX0eI7Js093MM6MacKU4M6dnCRa/QPDwYMxjljzSCzzlzKzj9Pk4P3OtrPcxr2N3znR419nr3Xw+65A==
   /@babel/plugin-transform-react-jsx/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -921,6 +1518,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-L+MfRhWjX0eI7Js093MM6MacKU4M6dnCRa/QPDwYMxjljzSCzzlzKzj9Pk4P3OtrPcxr2N3znR419nr3Xw+65A==
+  /@babel/plugin-transform-react-pure-annotations/7.10.4:
+    dependencies:
+      '@babel/helper-annotate-as-pure': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-+njZkqcOuS8RaPakrnR9KvxjoG1ASJWpoIv/doyWngId88JoFlPlISenGXjrVacZUIALGUr6eodRs1vmPnF23A==
   /@babel/plugin-transform-react-pure-annotations/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -931,6 +1537,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-+njZkqcOuS8RaPakrnR9KvxjoG1ASJWpoIv/doyWngId88JoFlPlISenGXjrVacZUIALGUr6eodRs1vmPnF23A==
+  /@babel/plugin-transform-regenerator/7.10.4:
+    dependencies:
+      regenerator-transform: 0.14.5
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-3thAHwtor39A7C04XucbMg17RcZ3Qppfxr22wYzZNcVIkPHfpM9J0SO8zuCV6SZa265kxBJSrfKTvDCYqBFXGw==
   /@babel/plugin-transform-regenerator/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -940,6 +1554,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-3thAHwtor39A7C04XucbMg17RcZ3Qppfxr22wYzZNcVIkPHfpM9J0SO8zuCV6SZa265kxBJSrfKTvDCYqBFXGw==
+  /@babel/plugin-transform-reserved-words/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-hGsw1O6Rew1fkFbDImZIEqA8GoidwTAilwCyWqLBM9f+e/u/sQMQu7uX6dyokfOayRuuVfKOW4O7HvaBWM+JlQ==
   /@babel/plugin-transform-reserved-words/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -949,6 +1571,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-hGsw1O6Rew1fkFbDImZIEqA8GoidwTAilwCyWqLBM9f+e/u/sQMQu7uX6dyokfOayRuuVfKOW4O7HvaBWM+JlQ==
+  /@babel/plugin-transform-shorthand-properties/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-AC2K/t7o07KeTIxMoHneyX90v3zkm5cjHJEokrPEAGEy3UCp8sLKfnfOIGdZ194fyN4wfX/zZUWT9trJZ0qc+Q==
   /@babel/plugin-transform-shorthand-properties/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -958,6 +1588,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-AC2K/t7o07KeTIxMoHneyX90v3zkm5cjHJEokrPEAGEy3UCp8sLKfnfOIGdZ194fyN4wfX/zZUWT9trJZ0qc+Q==
+  /@babel/plugin-transform-spread/7.11.0:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-skip-transparent-expression-wrappers': 7.11.0
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-UwQYGOqIdQJe4aWNyS7noqAnN2VbaczPLiEtln+zPowRNlD+79w3oi2TWfYe0eZgd+gjZCbsydN7lzWysDt+gw==
   /@babel/plugin-transform-spread/7.11.0_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -968,6 +1607,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-UwQYGOqIdQJe4aWNyS7noqAnN2VbaczPLiEtln+zPowRNlD+79w3oi2TWfYe0eZgd+gjZCbsydN7lzWysDt+gw==
+  /@babel/plugin-transform-sticky-regex/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-regex': 7.10.5
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-Ddy3QZfIbEV0VYcVtFDCjeE4xwVTJWTmUtorAJkn6u/92Z/nWJNV+mILyqHKrUxXYKA2EoCilgoPePymKL4DvQ==
   /@babel/plugin-transform-sticky-regex/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -978,6 +1626,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Ddy3QZfIbEV0VYcVtFDCjeE4xwVTJWTmUtorAJkn6u/92Z/nWJNV+mILyqHKrUxXYKA2EoCilgoPePymKL4DvQ==
+  /@babel/plugin-transform-template-literals/7.10.5:
+    dependencies:
+      '@babel/helper-annotate-as-pure': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-V/lnPGIb+KT12OQikDvgSuesRX14ck5FfJXt6+tXhdkJ+Vsd0lDCVtF6jcB4rNClYFzaB2jusZ+lNISDk2mMMw==
   /@babel/plugin-transform-template-literals/7.10.5_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -988,6 +1645,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-V/lnPGIb+KT12OQikDvgSuesRX14ck5FfJXt6+tXhdkJ+Vsd0lDCVtF6jcB4rNClYFzaB2jusZ+lNISDk2mMMw==
+  /@babel/plugin-transform-typeof-symbol/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-QqNgYwuuW0y0H+kUE/GWSR45t/ccRhe14Fs/4ZRouNNQsyd4o3PG4OtHiIrepbM2WKUBDAXKCAK/Lk4VhzTaGA==
   /@babel/plugin-transform-typeof-symbol/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -997,6 +1662,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-QqNgYwuuW0y0H+kUE/GWSR45t/ccRhe14Fs/4ZRouNNQsyd4o3PG4OtHiIrepbM2WKUBDAXKCAK/Lk4VhzTaGA==
+  /@babel/plugin-transform-unicode-escapes/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-y5XJ9waMti2J+e7ij20e+aH+fho7Wb7W8rNuu72aKRwCHFqQdhkdU2lo3uZ9tQuboEJcUFayXdARhcxLQ3+6Fg==
   /@babel/plugin-transform-unicode-escapes/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1006,6 +1679,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-y5XJ9waMti2J+e7ij20e+aH+fho7Wb7W8rNuu72aKRwCHFqQdhkdU2lo3uZ9tQuboEJcUFayXdARhcxLQ3+6Fg==
+  /@babel/plugin-transform-unicode-regex/7.10.4:
+    dependencies:
+      '@babel/helper-create-regexp-features-plugin': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-wNfsc4s8N2qnIwpO/WP2ZiSyjfpTamT2C9V9FDH/Ljub9zw6P3SjkXcFmc0RQUt96k2fmIvtla2MMjgTwIAC+A==
   /@babel/plugin-transform-unicode-regex/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1016,6 +1698,81 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-wNfsc4s8N2qnIwpO/WP2ZiSyjfpTamT2C9V9FDH/Ljub9zw6P3SjkXcFmc0RQUt96k2fmIvtla2MMjgTwIAC+A==
+  /@babel/preset-env/7.11.0:
+    dependencies:
+      '@babel/compat-data': 7.11.0
+      '@babel/helper-compilation-targets': 7.10.4
+      '@babel/helper-module-imports': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-proposal-async-generator-functions': 7.10.5
+      '@babel/plugin-proposal-class-properties': 7.10.4
+      '@babel/plugin-proposal-dynamic-import': 7.10.4
+      '@babel/plugin-proposal-export-namespace-from': 7.10.4
+      '@babel/plugin-proposal-json-strings': 7.10.4
+      '@babel/plugin-proposal-logical-assignment-operators': 7.11.0
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.10.4
+      '@babel/plugin-proposal-numeric-separator': 7.10.4
+      '@babel/plugin-proposal-object-rest-spread': 7.11.0
+      '@babel/plugin-proposal-optional-catch-binding': 7.10.4
+      '@babel/plugin-proposal-optional-chaining': 7.11.0
+      '@babel/plugin-proposal-private-methods': 7.10.4
+      '@babel/plugin-proposal-unicode-property-regex': 7.10.4
+      '@babel/plugin-syntax-async-generators': 7.8.4
+      '@babel/plugin-syntax-class-properties': 7.10.4
+      '@babel/plugin-syntax-dynamic-import': 7.8.3
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3
+      '@babel/plugin-syntax-json-strings': 7.8.3
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3
+      '@babel/plugin-syntax-numeric-separator': 7.10.4
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3
+      '@babel/plugin-syntax-optional-chaining': 7.8.3
+      '@babel/plugin-syntax-top-level-await': 7.10.4
+      '@babel/plugin-transform-arrow-functions': 7.10.4
+      '@babel/plugin-transform-async-to-generator': 7.10.4
+      '@babel/plugin-transform-block-scoped-functions': 7.10.4
+      '@babel/plugin-transform-block-scoping': 7.11.1
+      '@babel/plugin-transform-classes': 7.10.4
+      '@babel/plugin-transform-computed-properties': 7.10.4
+      '@babel/plugin-transform-destructuring': 7.10.4
+      '@babel/plugin-transform-dotall-regex': 7.10.4
+      '@babel/plugin-transform-duplicate-keys': 7.10.4
+      '@babel/plugin-transform-exponentiation-operator': 7.10.4
+      '@babel/plugin-transform-for-of': 7.10.4
+      '@babel/plugin-transform-function-name': 7.10.4
+      '@babel/plugin-transform-literals': 7.10.4
+      '@babel/plugin-transform-member-expression-literals': 7.10.4
+      '@babel/plugin-transform-modules-amd': 7.10.5
+      '@babel/plugin-transform-modules-commonjs': 7.10.4
+      '@babel/plugin-transform-modules-systemjs': 7.10.5
+      '@babel/plugin-transform-modules-umd': 7.10.4
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.10.4
+      '@babel/plugin-transform-new-target': 7.10.4
+      '@babel/plugin-transform-object-super': 7.10.4
+      '@babel/plugin-transform-parameters': 7.10.5
+      '@babel/plugin-transform-property-literals': 7.10.4
+      '@babel/plugin-transform-regenerator': 7.10.4
+      '@babel/plugin-transform-reserved-words': 7.10.4
+      '@babel/plugin-transform-shorthand-properties': 7.10.4
+      '@babel/plugin-transform-spread': 7.11.0
+      '@babel/plugin-transform-sticky-regex': 7.10.4
+      '@babel/plugin-transform-template-literals': 7.10.5
+      '@babel/plugin-transform-typeof-symbol': 7.10.4
+      '@babel/plugin-transform-unicode-escapes': 7.10.4
+      '@babel/plugin-transform-unicode-regex': 7.10.4
+      '@babel/preset-modules': 0.1.3
+      '@babel/types': 7.11.0
+      browserslist: 4.14.0
+      core-js-compat: 3.6.5
+      invariant: 2.2.4
+      levenary: 1.1.1
+      semver: 5.7.1
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-2u1/k7rG/gTh02dylX2kL3S0IJNF+J6bfDSp4DI2Ma8QN6Y9x9pmAax59fsCk6QUQG0yqH47yJWA+u1I1LccAg==
   /@babel/preset-env/7.11.0_@babel+core@7.11.4:
     dependencies:
       '@babel/compat-data': 7.11.0
@@ -1092,6 +1849,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-2u1/k7rG/gTh02dylX2kL3S0IJNF+J6bfDSp4DI2Ma8QN6Y9x9pmAax59fsCk6QUQG0yqH47yJWA+u1I1LccAg==
+  /@babel/preset-flow/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-transform-flow-strip-types': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-XI6l1CptQCOBv+ZKYwynyswhtOKwpZZp5n0LG1QKCo8erRhqjoQV6nvx61Eg30JHpysWQSBwA2AWRU3pBbSY5g==
   /@babel/preset-flow/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1102,6 +1868,18 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-XI6l1CptQCOBv+ZKYwynyswhtOKwpZZp5n0LG1QKCo8erRhqjoQV6nvx61Eg30JHpysWQSBwA2AWRU3pBbSY5g==
+  /@babel/preset-modules/0.1.3:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-proposal-unicode-property-regex': 7.10.4
+      '@babel/plugin-transform-dotall-regex': 7.10.4
+      '@babel/types': 7.9.5
+      esutils: 2.0.3
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==
   /@babel/preset-modules/0.1.3_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1115,6 +1893,20 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==
+  /@babel/preset-react/7.10.4:
+    dependencies:
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-transform-react-display-name': 7.10.4
+      '@babel/plugin-transform-react-jsx': 7.10.4
+      '@babel/plugin-transform-react-jsx-development': 7.10.4
+      '@babel/plugin-transform-react-jsx-self': 7.10.4
+      '@babel/plugin-transform-react-jsx-source': 7.10.5
+      '@babel/plugin-transform-react-pure-annotations': 7.10.4
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-BrHp4TgOIy4M19JAfO1LhycVXOPWdDbTRep7eVyatf174Hff+6Uk53sDyajqZPu8W1qXRBiYOfIamek6jA7YVw==
   /@babel/preset-react/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1130,6 +1922,18 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-BrHp4TgOIy4M19JAfO1LhycVXOPWdDbTRep7eVyatf174Hff+6Uk53sDyajqZPu8W1qXRBiYOfIamek6jA7YVw==
+  /@babel/register/7.10.5:
+    dependencies:
+      find-cache-dir: 2.1.0
+      lodash: 4.17.20
+      make-dir: 2.1.0
+      pirates: 4.0.1
+      source-map-support: 0.5.19
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-eYHdLv43nyvmPn9bfNfrcC4+iYNwdQ8Pxk1MFJuU/U5LpSYl/PH4dFMazCYZDFVi8ueG3shvO+AQfLrxpYulQw==
   /@babel/register/7.10.5_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1171,6 +1975,20 @@ packages:
     dev: false
     resolution:
       integrity: sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==
+  /@babel/traverse/7.11.5:
+    dependencies:
+      '@babel/code-frame': 7.10.4
+      '@babel/generator': 7.11.6
+      '@babel/helper-function-name': 7.10.4
+      '@babel/helper-split-export-declaration': 7.11.0
+      '@babel/parser': 7.11.5
+      '@babel/types': 7.11.5
+      debug: 4.1.1
+      globals: 11.12.0
+      lodash: 4.17.20
+    dev: false
+    resolution:
+      integrity: sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==
   /@babel/traverse/7.9.5:
     dependencies:
       '@babel/code-frame': 7.10.4
@@ -1193,6 +2011,14 @@ packages:
     dev: false
     resolution:
       integrity: sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==
+  /@babel/types/7.11.5:
+    dependencies:
+      '@babel/helper-validator-identifier': 7.10.4
+      lodash: 4.17.20
+      to-fast-properties: 2.0.0
+    dev: false
+    resolution:
+      integrity: sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==
   /@babel/types/7.9.5:
     dependencies:
       '@babel/helper-validator-identifier': 7.10.4
@@ -2242,6 +3068,22 @@ packages:
   /babel-loader/8.1.0_fbab4801791d746d265885e0d19f0bda:
     dependencies:
       '@babel/core': 7.11.4
+      find-cache-dir: 2.1.0
+      loader-utils: 1.4.0
+      mkdirp: 0.5.5
+      pify: 4.0.1
+      schema-utils: 2.7.0
+      webpack: 4.44.1_webpack@4.44.1
+    dev: false
+    engines:
+      node: '>= 6.9'
+    peerDependencies:
+      '@babel/core': ^7.0.0
+      webpack: '>=2'
+    resolution:
+      integrity: sha512-7q7nC1tYOrqvUrN3LQK4GwSk/TQorZSOlO9C+RZDZpODgyN4ZlCqE5q9cDsyWOliN+aU9B4JX01xK9eJXowJLw==
+  /babel-loader/8.1.0_webpack@4.44.1:
+    dependencies:
       find-cache-dir: 2.1.0
       loader-utils: 1.4.0
       mkdirp: 0.5.5
@@ -5011,6 +5853,19 @@ packages:
       node: '>=4.x'
     resolution:
       integrity: sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
+  /gulp-babel/8.0.0:
+    dependencies:
+      plugin-error: 1.0.1
+      replace-ext: 1.0.1
+      through2: 2.0.5
+      vinyl-sourcemaps-apply: 0.2.1
+    dev: false
+    engines:
+      node: '>=6'
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    resolution:
+      integrity: sha512-oomaIqDXxFkg7lbpBou/gnUkX51/Y/M2ZfSjL2hdqXTAlSWZcgZtd2o0cOH0r/eE8LWD0+Q/PsLsr2DKOoqToQ==
   /gulp-babel/8.0.0_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -10023,7 +10878,7 @@ packages:
     dev: false
     name: '@rush-temp/example'
     resolution:
-      integrity: sha512-4hLhvqCZ21muVOTkwESI9iBtHMsjZp6YKTzG41dTzVz8x41KPHOdi43uAZQsegT/q/frOxA8vNmapxQgTGVjeg==
+      integrity: sha512-OdMERtUI3/VpikZuxrb/NhXQ+yUlqyeFrzxjro8rgQT0kdEMKBvUCuFNY8RsgN659TrauZ8L+KT98uxQNj1IGQ==
       tarball: 'file:projects/example.tgz'
     version: 0.0.0
   'file:projects/externalize.tgz':
@@ -10050,7 +10905,7 @@ packages:
     version: 0.0.0
   'file:projects/legacy-template.tgz':
     dependencies:
-      '@babel/core': 7.11.4
+      '@babel/core': 7.11.6
       bluebird: 3.7.2
       code-prettify: 0.1.0
       color-themes-for-google-code-prettify: 2.0.4
@@ -10068,7 +10923,7 @@ packages:
     dev: false
     name: '@rush-temp/legacy-template'
     resolution:
-      integrity: sha512-i+vax6pWlhlRFNfAKgDDk/HTsSIZnE6J2wxFQ+aJzLepNgUDP7KdL0wHfl4J2tmHvMPZktcTcyMlhaBuFmkY2Q==
+      integrity: sha512-nMPg+aujOZArJwNrswXTtRYVELOfym1544eBfEkXFMI8AM89Iv6Q0nJDxeehCqPZL2PaRMdgVwgh/bjqFlMCBA==
       tarball: 'file:projects/legacy-template.tgz'
     version: 0.0.0
   'file:projects/model.tgz':
@@ -10199,7 +11054,6 @@ packages:
 registry: ''
 specifiers:
   '@babel/cli': ^7.8.4
-  '@babel/core': ^7.9.0
   '@babel/parser': ^7.9.4
   '@babel/plugin-proposal-class-properties': ^7.8.3
   '@babel/plugin-transform-flow-comments': ^7.8.3

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -67,8 +67,10 @@ dependencies:
   open-sans-fonts: 1.6.2
   optimize-css-assets-webpack-plugin: 5.0.3_webpack@4.44.1
   parse-github-url: 1.0.2
+  pkg-up: 3.1.0
   react: 16.13.1
   react-dom: 16.13.1_react@16.13.1
+  read-pkg-up: 7.0.1
   requizzle: 0.2.3
   sass: 1.26.10
   sass-loader: 9.0.3_sass@1.26.10+webpack@4.44.1
@@ -1530,6 +1532,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA==
+  /@types/normalize-package-data/2.4.0:
+    dev: false
+    resolution:
+      integrity: sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
   /@types/prop-types/15.7.3:
     dev: false
     resolution:
@@ -5843,6 +5849,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
+  /json-parse-even-better-errors/2.3.1:
+    dev: false
+    resolution:
+      integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
   /json-schema-traverse/0.4.1:
     dev: false
     resolution:
@@ -6091,6 +6101,10 @@ packages:
       node: '>= 0.8'
     resolution:
       integrity: sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==
+  /lines-and-columns/1.1.6:
+    dev: false
+    resolution:
+      integrity: sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
   /linkify-it/2.2.0:
     dependencies:
       uc.micro: 1.0.6
@@ -7213,6 +7227,17 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
+  /parse-json/5.1.0:
+    dependencies:
+      '@babel/code-frame': 7.10.4
+      error-ex: 1.3.2
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.1.6
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==
   /parse-node-version/1.0.1:
     dev: false
     engines:
@@ -7385,6 +7410,14 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
+  /pkg-up/3.1.0:
+    dependencies:
+      find-up: 3.0.0
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   /plugin-error/1.0.1:
     dependencies:
       ansi-colors: 1.1.0
@@ -7967,6 +8000,16 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=
+  /read-pkg-up/7.0.1:
+    dependencies:
+      find-up: 4.1.0
+      read-pkg: 5.2.0
+      type-fest: 0.8.1
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==
   /read-pkg/1.1.0:
     dependencies:
       load-json-file: 1.1.0
@@ -7987,6 +8030,17 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=
+  /read-pkg/5.2.0:
+    dependencies:
+      '@types/normalize-package-data': 2.4.0
+      normalize-package-data: 2.5.0
+      parse-json: 5.1.0
+      type-fest: 0.6.0
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==
   /readable-stream/1.1.14:
     dependencies:
       core-util-is: 1.0.2
@@ -9223,6 +9277,12 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
+  /type-fest/0.6.0:
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
   /type-fest/0.8.1:
     dev: false
     engines:
@@ -9882,12 +9942,14 @@ packages:
       missionlog: 1.6.0
       mocha: 7.2.0
       object.fromentries: 2.0.2
+      pkg-up: 3.1.0
+      read-pkg-up: 7.0.1
       requizzle: 0.2.3
       yargs: 15.3.1
     dev: false
     name: '@rush-temp/cli'
     resolution:
-      integrity: sha512-btK/1/qLuq6jw1lBnNYYfl5eZR2VoxWi7hwl0UFPuuFyFRQMIw7NZplh7kVV5Acb2Cui5jd7iSl0660+ej6hxQ==
+      integrity: sha512-jHwioCAMZd0G+tXEoMu0z0P32McdvLYbsgG7gZB/xlJK6WLW+CZkyF0o0o+YKXyAMS5Qn/wp6B/Y8Naw2kS/uQ==
       tarball: 'file:projects/cli.tgz'
     version: 0.0.0
   'file:projects/default-template.tgz':
@@ -10134,6 +10196,7 @@ packages:
       integrity: sha512-maxudznjgJEhASCC8FSBY42y0jNeTsC8qD+VqHy4OwuohcnBX0UtjTX4e3yJauqjefEzEwQbGTP3ZninK/VazQ==
       tarball: 'file:projects/types.tgz'
     version: 0.0.0
+registry: ''
 specifiers:
   '@babel/cli': ^7.8.4
   '@babel/core': ^7.9.0
@@ -10203,8 +10266,10 @@ specifiers:
   open-sans-fonts: ^1.6.2
   optimize-css-assets-webpack-plugin: ^5.0.3
   parse-github-url: 1.0.2
+  pkg-up: ~3.1.0
   react: ^16.8.0
   react-dom: ^16.8.0
+  read-pkg-up: ~7.0.1
   requizzle: 0.2.3
   sass: ^1.26.10
   sass-loader: ^9.0.3

--- a/example.api.json
+++ b/example.api.json
@@ -1,0 +1,629 @@
+{
+	"type": "RootDoc",
+	"children": [
+		{
+			"name": "WebdocParser",
+			"type": "ClassDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "STAGE_AST_LIKE",
+			"type": "PropertyDoc",
+			"brief": "",
+			"description": "<p>The doctree-mod should run when the &quot;members&quot; are resolved to their actual AST parent. This\noccurs after {@code STAGE_BLANK}.</p>\n<p>Example:</p>\n<pre><code class=\"hljs language-js\"><span class=\"hljs-class\"><span class=\"hljs-keyword\">class</span> <span class=\"hljs-title\">DocumentedClass</span> </span>{\n  <span class=\"hljs-keyword\">constructor</span>() {\n    <span class=\"hljs-comment\">/** <span class=\"hljs-doctag\">@member <span class=\"hljs-type\">{string) *\\/\n    this.instanceProperty = \"defaultValue\";\n    /** @member {string}</span> </span>*\\/\n    DocumentedClass.instanceCount = DocumentedClass.instanceCount\n      ? DocumentedClass.instanceCount + 1 : 1;\n  }\n}\n</span></code></pre>\n<p>Before STAGE_AST_LIKE, the symbols <code>instanceProperty</code> and <code>instanceCount</code> will be a child of\n<code>DocumentedClass#constructor</code>. However, in STAGE_ASK_LIKE, they will be resolved as children of\n<code>DocumentedClass</code>.</p>"
+		},
+		{
+			"name": "STAGE_BLANK",
+			"type": "PropertyDoc",
+			"brief": "",
+			"description": "<p>The doctree-mod should run before all other mods.</p>"
+		},
+		{
+			"name": "STAGE_FINISHED",
+			"type": "PropertyDoc",
+			"brief": "",
+			"description": "<p>This stage occurs after all symbol-hierarchy operations are done. This is the best place for\ndoctree-mods that simply alter the doc content without using the parent/members relations.</p>\n<p>This occurs after {@code STAGE_SYMBOLS_DISCOVERED}.</p>"
+		},
+		{
+			"name": "STAGE_SYMBOLS_RESOLVED",
+			"type": "PropertyDoc",
+			"brief": "",
+			"description": "<p>The doctree-mod should run when symbols are placed in their documented parents. The\n<code>@modResolveMemberof</code> tag is resolved in this stage. This occurs after {@code STAGE_AST_LIKE}.</p>\n<p>Example:</p>\n<pre><code class=\"hljs language-js\"><span class=\"hljs-comment\">/**\n * <span class=\"hljs-doctag\">@namespace <span class=\"hljs-variable\">NS</span></span>\n *\\/\n\n/**\n * <span class=\"hljs-doctag\">@modResolveMemberof <span class=\"hljs-variable\">NS</span></span>\n *\\/\nclass API {}\n</span></code></pre>\n<p>Before {@code STAGE_SYMBOLS_RESOLVED}, the symbol {@code API} won't have a parent. However, in\n{@code STAGE_SYMBOLS_RESOLVED}, the symbol {@code API} will be a child of {@code NS}.</p>"
+		},
+		{
+			"name": "createHeadlessSymbol",
+			"type": "MethodDoc",
+			"scope": "instance",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "del",
+			"type": "MethodDoc",
+			"scope": "instance",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "logRecursive",
+			"type": "MethodDoc",
+			"scope": "instance",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "parse",
+			"type": "MethodDoc",
+			"scope": "instance",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "TagParser",
+			"type": "MethodDoc",
+			"scope": "instance",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "addChildDoc",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "addChildSymbol",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "addDoc",
+			"type": "FunctionDoc",
+			"brief": "<p>Adds a doc at its path in the doc-tree.</p>",
+			"description": ""
+		},
+		{
+			"name": "applyDefaultLangConfig",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "assemble",
+			"type": "FunctionDoc",
+			"brief": "<p>Assembles the symbol-metadata trees of each source-file into one, monolithic tree.</p>",
+			"description": ""
+		},
+		{
+			"name": "buildSymbolTree",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": "",
+			"children": [
+				{
+					"name": "enter",
+					"type": "MethodDoc",
+					"scope": "instance",
+					"brief": "",
+					"description": ""
+				},
+				{
+					"name": "exit",
+					"type": "MethodDoc",
+					"scope": "instance",
+					"brief": "",
+					"description": ""
+				}
+			]
+		},
+		{
+			"name": "childDoc",
+			"type": "FunctionDoc",
+			"brief": "<p>Searches for the doc named {@code lname} in the given scoped documentation.</p>",
+			"description": ""
+		},
+		{
+			"name": "clearRegistry",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "cloneDoc",
+			"type": "FunctionDoc",
+			"brief": "<p>Clones the doc without its children or parent.</p>",
+			"description": ""
+		},
+		{
+			"name": "cloneType",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "coalescePair",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "createBlock",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "createDataType",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "createDoc",
+			"type": "FunctionDoc",
+			"brief": "<p>Creates a valid doc object with a name &amp; type.</p>",
+			"description": ""
+		},
+		{
+			"name": "createRestDataType",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "createSimpleDocumentedType",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "declareParameter",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "discoverMembers",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "doc",
+			"type": "FunctionDoc",
+			"brief": "<p>Finds the doc whose relative path is {@code path} w.r.t {@code root}.</p>",
+			"description": ""
+		},
+		{
+			"name": "ensureDiscovered",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "exportTaffy",
+			"type": "FunctionDoc",
+			"brief": "<p>Exports a doc-tree in a TaffyDB database. The docs are inserted in a depth-first order.</p>",
+			"description": ""
+		},
+		{
+			"name": "extract",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": "<p>Extracts the documentation of the node, if one exists. This also handles the case where the node\nitself is a documentation comment.</p>"
+		},
+		{
+			"name": "extractDataValue",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "extractExtends",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "extractIdentifier",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "extractParams",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "extractSymbol",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "extractType",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "filterComments",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "findSymbol",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "generateComparator",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "initLogger",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "isClass",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "isExternal",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "isInterface",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "isModule",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "isNamespace",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "isObligateLeaf",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "isParentThis",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "isProperty",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "loadTutorials",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "matchDataTypeClosure",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "memberofResolve",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "mergeParams",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "modAssembly",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "morphTutorials",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "packageApi",
+			"type": "FunctionDoc",
+			"brief": "<p>Resolves each package's top-level API docs.</p>",
+			"description": ""
+		},
+		{
+			"name": "packages",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "parse",
+			"type": "FunctionDoc",
+			"brief": "<p>Parses the file(s) into a doc-tree. This consists of the following phases:</p>",
+			"description": "<ul>\n<li>Capture Phase: Documentation comments are extracted out of each file and assembled into\na temporary list of partial-doc trees.</li>\n<li>Transform Phase: Each file's partial-doc tree is transformed into docs and assembled in\nmonolithic doc-tree.</li>\n<li>Mod Phase: The &quot;@memberof&quot; tag is handled by moving docs to their final path;\n<this> member docs are moved to the appropriate scope.\nPlugins are allowed access to make any post-transform changes as well. Undocumented entities\nare removed from the doc-tree.</li>\n</ul>"
+		},
+		{
+			"name": "parseAbstract",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "parseCopyright",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "parseDeprecated",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "parseEvent",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "parseFires",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "parseImplements",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "parseInstance",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "parseLicense",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "parsePrivate",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "parseProperty",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "parsePublic",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "parseScope",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "parseSince",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "parseTodo",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "parseType",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "parseTypedDescription",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "queueTargets",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "readDoctree",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": "<p>Imports the doctree from the JSON format string-data. This will not recover all of the\ninformation in the original doctree.</p>"
+		},
+		{
+			"name": "registerDoctreeMod",
+			"type": "FunctionDoc",
+			"brief": "<p>Registers the doctree-mod so that it will run when {@code parse} is invoked.</p>",
+			"description": "<p>NOTE: This is an internal API. If you're writing a plugin, use the\n{@code Parser#installDoctreeMod} API instead.</p>\n<p>HINT: If your doctree-mod isn't affected by the relations b/w different symbols, then you should\npick {@code STAGE_FINISHED}.</p>"
+		},
+		{
+			"name": "registerObjectPropertyVariables",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "registerParameters",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "registerValidator",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "registerWebdocParser",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": "",
+			"children": [
+				{
+					"name": "installPlugin",
+					"type": "MethodDoc",
+					"scope": "instance",
+					"brief": "",
+					"description": ""
+				}
+			]
+		},
+		{
+			"name": "resolveAssignedMembersRecursive",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "resolvedThis",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "resolveLinkArray",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "resolveRelated",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": "<ul>\n<li>\n<p>Resolves all docs listed in the &quot;extends&quot;, &quot;implements&quot;, &quot;mixes&quot;. This prevent redundant\nsearches to extended/implemented/mixed symbols.</p>\n</li>\n<li>\n<p>Replaces the &quot;default&quot; scopes for properties with a good guess. (The @property tag parser puts\n&quot;default&quot; scope on the PropertyDocs it creates)</p>\n</li>\n<li>\n<p>Brings down any methods/properties coming from parent classes &amp; mixins. Adds the implementation\nproperty to methods/properties that come from interfaces.</p>\n</li>\n</ul>"
+		},
+		{
+			"name": "resolveReturn",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "resolveRootObject",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "resolveToObject",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "searchExtendedClasses",
+			"type": "FunctionDoc",
+			"brief": "<p>Finds all the symbols that are extended by {@code doc}.</p>",
+			"description": ""
+		},
+		{
+			"name": "searchImplementedInterfaces",
+			"type": "FunctionDoc",
+			"brief": "<p>Finds all the symbols that are implemented by {@code doc}.</p>",
+			"description": ""
+		},
+		{
+			"name": "symbolToDoc",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "transformRecursive",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "traverse",
+			"type": "FunctionDoc",
+			"brief": "<p>Preorder traversal of all the docs</p>",
+			"description": ""
+		},
+		{
+			"name": "tutorialDoc",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "updateScope",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "updateStage",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "validateParameters",
+			"type": "FunctionDoc",
+			"brief": "",
+			"description": ""
+		},
+		{
+			"name": "writeDoctree",
+			"type": "FunctionDoc",
+			"brief": "<p>Exports the doctree to a JSON string.</p>",
+			"description": ""
+		}
+	]
+}

--- a/example/package.json
+++ b/example/package.json
@@ -23,7 +23,8 @@
   },
   "scripts": {
     "unit-test": "",
-    "build": "webdoc --tutorials ./tutorials"
+    "build": "webdoc --tutorials ./tutorials",
+    "build-next": "cd ..; webdoc; cd example"
   },
   "bugs": {
     "url": "https://github.com/SukantPal/webdoc/issues"
@@ -33,6 +34,7 @@
   },
   "gitHead": "a2866c1a42f60180a74add7bc1b0f42d8bb16330",
   "devDependencies": {
-    "flow-typed": "^3.2.1"
+    "flow-typed": "^3.2.1",
+    "@webdoc/eslint-config": "~1.0.0"
   }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "unit-test": "",
     "build": "webdoc --tutorials ./tutorials",
-    "build-next": "cd ..; webdoc; cd example"
+    "build-next": "cd .. && webdoc && cd example"
   },
   "bugs": {
     "url": "https://github.com/SukantPal/webdoc/issues"

--- a/packages/webdoc-cli/package.json
+++ b/packages/webdoc-cli/package.json
@@ -57,7 +57,9 @@
     "gulp": "^4.0.2",
     "gulp-babel": "^8.0.0",
     "@babel/core": "^7.9.0",
-    "gulp-util": "^3.0.8"
+    "gulp-util": "^3.0.8",
+    "read-pkg-up": "~7.0.1",
+    "pkg-up": "~3.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/packages/webdoc-cli/src/config.js
+++ b/packages/webdoc-cli/src/config.js
@@ -33,6 +33,9 @@ const defaultConfig = {
     default: {
       includeDate: true,
     },
+    apiExplorer: {
+      mode: "package",
+    },
     repository: undefined, // ex. GitHub repo holding source files to link source files
     // should contain branch - https://github.com/webdoc-js/webdoc/blob/master/
   },

--- a/packages/webdoc-cli/src/index.js
+++ b/packages/webdoc-cli/src/index.js
@@ -85,8 +85,6 @@ async function main(argv: yargs.Arguments<>) {
     }
   }
 
-  const sourceFiles = sources(config);
-
   const documentTree: RootDoc = {
     children: [],
     path: "",
@@ -94,6 +92,8 @@ async function main(argv: yargs.Arguments<>) {
     type: "RootDoc",
     tags: [],
   };
+
+  const sourceFiles = sources(config, documentTree);
 
   documentTree.members = documentTree.children;
 

--- a/packages/webdoc-cli/src/index.js
+++ b/packages/webdoc-cli/src/index.js
@@ -7,11 +7,11 @@ import type {RootDoc} from "@webdoc/types";
 import {exportTaffy} from "@webdoc/model";
 import fs from "fs";
 import fse from "fs-extra";
-import globby from "globby";
 import {initLogger as initParserLogger} from "@webdoc/parser";
 import {loadTutorials} from "./load-tutorials";
 import path from "path";
 import {performance} from "perf_hooks";
+import {sources} from "./sources";
 import {writeDoctree} from "@webdoc/externalize";
 
 require("./shims");// Node v10 support
@@ -85,7 +85,7 @@ async function main(argv: yargs.Arguments<>) {
     }
   }
 
-  const sourceFiles = globby.sync(includePattern);
+  const sourceFiles = sources(config);
 
   const documentTree: RootDoc = {
     children: [],
@@ -97,19 +97,12 @@ async function main(argv: yargs.Arguments<>) {
 
   documentTree.members = documentTree.children;
 
-  const files = new Map();
-
-  for (let i = 0; i < sourceFiles.length; i++) {
-    log.info(tag.Parser, `Parsing ${sourceFiles[i]}`);
-    files.set(sourceFiles[i], fs.readFileSync(path.join(process.cwd(), sourceFiles[i]), "utf8"));
-  }
-
   if (config.opts.export) {
     fse.ensureFileSync(config.opts.export);
   }
 
   try {
-    parse(files, documentTree);
+    parse(sourceFiles, documentTree);
   } catch (e) {
     // Make sure we get that API structure out so the user can debug the problem!
     if (config.opts.export) {

--- a/packages/webdoc-cli/src/sources/index.js
+++ b/packages/webdoc-cli/src/sources/index.js
@@ -1,9 +1,8 @@
-import type {SourceFile} from "@webdoc/types";
+import type {RootDoc, SourceFile} from "@webdoc/types";
 import globby from "globby";
 import {packages} from "./packages";
-import {path} from "path";
 
-export function sources(config: Object): SourceFile[] {
+export function sources(config: Object, documentTree: RootDoc): SourceFile[] {
   const includePattern = config.source.includePattern || config.source.include;
 
   if (!includePattern) {
@@ -13,7 +12,7 @@ export function sources(config: Object): SourceFile[] {
   const paths = globby.sync(includePattern);
   const sources: SourceFile[] = paths.map((file) => ({path: file}));
 
-  packages(sources);
+  documentTree.packages = packages(sources);
 
   return sources;
 }

--- a/packages/webdoc-cli/src/sources/index.js
+++ b/packages/webdoc-cli/src/sources/index.js
@@ -1,0 +1,19 @@
+import type {SourceFile} from "@webdoc/types";
+import globby from "globby";
+import {packages} from "./packages";
+import {path} from "path";
+
+export function sources(config: Object): SourceFile[] {
+  const includePattern = config.source.includePattern || config.source.include;
+
+  if (!includePattern) {
+    console.log("No source.include or source.includePattern found in config file");
+  }
+
+  const paths = globby.sync(includePattern);
+  const sources: SourceFile[] = paths.map((file) => ({path: file}));
+
+  packages(sources);
+
+  return sources;
+}

--- a/packages/webdoc-cli/src/sources/packages.js
+++ b/packages/webdoc-cli/src/sources/packages.js
@@ -15,7 +15,7 @@ export function packages(sourceFiles: SourceFile[]): PackageDoc[] {
     let pkg = cache.get(dir);
 
     if (!pkg) {
-      const pkgJson = pkgUp.sync(file.path);
+      const pkgJson = pkgUp.sync({cwd: dir});
 
       // Attempt to get PackageDoc from package.json mapping
       pkg = cache.get(pkgJson);

--- a/packages/webdoc-cli/src/sources/packages.js
+++ b/packages/webdoc-cli/src/sources/packages.js
@@ -1,0 +1,43 @@
+// @flow
+
+import type {PackageDoc, SourceFile} from "@webdoc/types";
+import path from "path";
+import pkgUp from "pkg-up";
+
+export function packages(sourceFiles: SourceFile[]): PackageDoc[] {
+  const cache = new Map<string, PackageDoc>();
+  const packages: PackageDoc[] = [];
+
+  sourceFiles.forEach((file) => {
+    const dir = path.dirname(file.path);
+
+    // Attempt to get PackageDoc from directory mapping
+    let pkg = cache.get(dir);
+
+    if (!pkg) {
+      const pkgJson = pkgUp.sync(file.path);
+
+      // Attempt to get PackageDoc from package.json mapping
+      pkg = cache.get(pkgJson);
+
+      if (!pkg) {
+        // Create PackageDoc for this package
+        pkg = {
+          api: [],
+          location: pkgJson,
+          metadata: require(path.relative(__dirname, pkgJson)),
+          type: "PackageDoc",
+        };
+
+        packages.push(pkg);
+        cache.set(pkgJson, pkg);
+      }
+
+      cache.set(dir, pkg);
+    }
+
+    file.package = pkg;
+  });
+
+  return packages;
+}

--- a/packages/webdoc-default-template/helper/crawl/crawl-reference-explorer.js
+++ b/packages/webdoc-default-template/helper/crawl/crawl-reference-explorer.js
@@ -38,8 +38,6 @@ function crawlReference(doc /*: Doc */) {
 
   const tree = buildExplorerTargetsTree(explorerHierarchy);
 
-  console.log(tree.children.Packages[0].children.Classes);
-
   return tree;
 }
 

--- a/packages/webdoc-default-template/helper/crawl/crawl-reference-explorer.js
+++ b/packages/webdoc-default-template/helper/crawl/crawl-reference-explorer.js
@@ -4,7 +4,12 @@ const {SymbolLinks} = require("@webdoc/template-library");
 const {traverse} = require("@webdoc/model");
 
 /*::
-import type {DocType} from "@webdoc/types";
+import type {
+  Doc,
+  DocType,
+  PackageDoc,
+  RootDoc
+} from "@webdoc/types";
 import type {CategorizedDocumentList} from "./crawl";
 */
 
@@ -27,22 +32,15 @@ const HIERARCHY_SPECIFIERS = {
   "NSDoc": ["ClassDoc", "EnumDoc", "InterfaceDoc", "FunctionDoc", "TypedefDoc"],
 };
 
-// Categories into which API entities are divided
-const CATEGORIES = [
-  "namespaces",
-  "classes",
-  "enums",
-  "events",
-  "mixins",
-  "interfaces",
-  "typedefs",
-];
-
 // Crawls the tree searching for the API reference
 function crawlReference(doc /*: Doc */) {
-  const explorerHierarchy = buildExplorerHierarchy(doc);
+  const explorerHierarchy = buildExplorerHierarchy(doc, true);
 
-  return buildExplorerTargetsTree(explorerHierarchy);
+  const tree = buildExplorerTargetsTree(explorerHierarchy);
+
+  console.log(tree.children.Packages[0].children.Classes);
+
+  return tree;
 }
 
 exports.crawlReference = crawlReference;
@@ -53,14 +51,16 @@ type ExplorerNode = {
   children: CategorizedDocumentList,
 */
 
-function buildExplorerHierarchy(rootDoc /*: RootDoc */) /*: ExplorerNode */ {
+function buildExplorerHierarchy(rootDoc /*: RootDoc */, multiPackage = false) /*: ExplorerNode */ {
   const hierarchyStack /*: DocType[][] */ = [];
   const rootNode = {doc: rootDoc, children: {}};
 
-  traverse(rootDoc, {
+  let baseNode = rootNode;
+
+  const traversalContext = {
     enter(doc) {
-      if (doc.type === "RootDoc") {
-        hierarchyStack.push([rootNode]);
+      if (doc.type === "RootDoc" || doc.type === "PackageDoc") {
+        hierarchyStack.push([baseNode]);
         return;
       }
 
@@ -102,18 +102,71 @@ function buildExplorerHierarchy(rootDoc /*: RootDoc */) /*: ExplorerNode */ {
     exit(doc) {
       hierarchyStack.pop();
     },
-  });
+  };
+
+  if (!multiPackage) {
+    traverse(rootDoc, traversalContext);
+  } else {
+    rootNode.children.PackageDoc = [];
+
+    rootDoc.packages.forEach((pkgDoc) => {
+      const pkgNode = {
+        doc: pkgDoc,
+        children: {},
+      };
+
+      rootNode.children.PackageDoc.push(pkgNode);
+
+      baseNode = pkgNode;
+
+      traversePackage(pkgDoc, traversalContext);
+    });
+  }
 
   return rootNode;
+}
+
+/*::
+type PackageTraversalContext = {
+  [id: "enter" | "exit"]: (doc: Doc) => void,
+};
+*/
+
+function traversePackage(doc /*: Doc | PackageDoc */, context /*: Object */) {
+  if (doc.type !== "PackageDoc" &&
+    doc.parent.type !== "PackageDoc" &&
+    doc.parent.type !== "RootDoc" &&
+    doc.loc.file.package !== doc.parent.loc.file.package) {
+    // cannot enter into a different package's API
+    return;
+  }
+
+  context.enter(doc);
+
+  const arr = doc.members || doc.api;
+
+  for (let i = 0; i < arr.length; i++) {
+    traversePackage(arr[i], context);
+  }
+
+  context.exit(doc);
 }
 
 function buildExplorerTargetsTree(node /*: ExplorerNode */, parentTitle /*: string */ = "") /*: ExplorerTarget */ {
   const doc = node.doc;
   const page = SymbolLinks.pathToUrl.get(doc.path);
 
-  const sliceIndex = (parentTitle ? doc.path.indexOf(parentTitle) + parentTitle.length : -1) + 1;
+  let title = "";
 
-  node.title = doc.path.slice(sliceIndex);
+  if (doc.type !== "PackageDoc") {
+    const sliceIndex = (parentTitle ? doc.path.indexOf(parentTitle) + parentTitle.length : -1) + 1;
+
+    node.title = doc.path.slice(sliceIndex);
+    title = node.title;
+  } else {
+    node.title = doc.metadata.name;
+    // Don't pass on title for packages
+  }
 
   const childNodes = node.children;
   const childrenCategories = Object.keys(node.children);
@@ -136,7 +189,7 @@ function buildExplorerTargetsTree(node /*: ExplorerNode */, parentTitle /*: stri
     }
 
     for (const [key, value] of Object.entries(childNodes)) {
-      node.children[DOC_TYPE_TO_TITLE[key]] = value.map((cn) => buildExplorerTargetsTree(cn, node.title));
+      node.children[DOC_TYPE_TO_TITLE[key]] = value.map((cn) => buildExplorerTargetsTree(cn, title));
     }
 
     node.page = null;

--- a/packages/webdoc-default-template/helper/crawl/crawl-reference-explorer.js
+++ b/packages/webdoc-default-template/helper/crawl/crawl-reference-explorer.js
@@ -34,7 +34,7 @@ const HIERARCHY_SPECIFIERS = {
 
 // Crawls the tree searching for the API reference
 function crawlReference(doc /*: Doc */) {
-  const explorerHierarchy = buildExplorerHierarchy(doc, true);
+  const explorerHierarchy = buildExplorerHierarchy(doc, doc.packages ? (doc.packages.length > 1) : false);
 
   const tree = buildExplorerTargetsTree(explorerHierarchy);
 

--- a/packages/webdoc-legacy-template/.eslintrc.json
+++ b/packages/webdoc-legacy-template/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+    "ignorePatterns" : ["lib"],
+    "extends": [
+        "@webdoc/eslint-config"
+    ]
+}

--- a/packages/webdoc-legacy-template/babel.config.json
+++ b/packages/webdoc-legacy-template/babel.config.json
@@ -1,0 +1,3 @@
+{
+    "presets": [ "@webdoc/babel-preset" ]
+}

--- a/packages/webdoc-legacy-template/package.json
+++ b/packages/webdoc-legacy-template/package.json
@@ -54,8 +54,9 @@
     "open-sans-fonts": "^1.6.2"
   },
   "devDependencies": {
-    "@babel/core": "^7.9.0",
-    "flow-typed": "^3.2.1"
+    "flow-typed": "^3.2.1",
+    "@webdoc/babel-preset": "~1.0.0",
+    "@webdoc/eslint-config": "~1.0.0"
   },
   "gitHead": "326306f477098182404f813337c0c67cc90263c6"
 }

--- a/packages/webdoc-parser/src/parse.js
+++ b/packages/webdoc-parser/src/parse.js
@@ -50,9 +50,13 @@ export function applyDefaultLangConfig(cfg: LanguageConfig) {
 
 export function buildSymbolTree(
   file: string,
-  source?: SourceFile = {path: ".js"},
+  source?: SourceFile | string = {path: ".js"},
   config: LanguageConfig = Webdoc.DEFAULT_LANG_CONFIG,
 ): Symbol {
+  if (typeof source === "string") {
+    source = {path: source};
+  }
+
   const fileName = source.path;
   const lang = languages[fileName.substring(fileName.lastIndexOf(".") + 1, fileName.length)];
 
@@ -89,7 +93,7 @@ export function parse(target: string | SourceFile[], root?: RootDoc = {
   tags: [],
 }): RootDoc {
   if (typeof target === "string") {
-    target = [{content: target, path: "", package: null}];
+    target = [{content: target, path: ".js", package: null}];
   }
 
   const partialDoctrees = new Array(Array.isArray(target) ? target.length : target.size);

--- a/packages/webdoc-parser/src/parse.js
+++ b/packages/webdoc-parser/src/parse.js
@@ -2,12 +2,14 @@
 /* global Webdoc */
 
 import type {LanguageConfig, LanguageIntegration} from "./types/LanguageIntegration";
+import type {RootDoc, SourceFile} from "@webdoc/types";
 import {langJS, langTS} from "./symbols-babel";
-import type {RootDoc} from "@webdoc/types";
 import type {Symbol} from "./types/Symbol";
 import assemble from "./assembler";
+import fs from "fs";
 import mod from "./transformer/document-tree-modifiers";
 import {parserLogger} from "./Logger";
+import path from "path";
 import transform from "./transformer";
 
 // File-extension -> LanguageIntegration mapping
@@ -78,7 +80,7 @@ export function buildSymbolTree(
  * @param {RootDoc} root
  * @return {RootDoc}
  */
-export function parse(target: string | string[] | Map<string, string>, root?: RootDoc = {
+export function parse(target: string | SourceFile[] | Map<string, string>, root?: RootDoc = {
   members: [],
   path: "",
   stack: [""],
@@ -94,7 +96,12 @@ export function parse(target: string | string[] | Map<string, string>, root?: Ro
   // Build a symbol-tree for all the files
   if (Array.isArray(target)) {
     for (let i = 0; i < target.length; i++) {
-      partialDoctrees[i] = buildSymbolTree(target[i]);
+      const {content, path: source} = target[i];
+
+      partialDoctrees[i] = buildSymbolTree(
+        content || fs.readFileSync(path.join(process.cwd(), source), "utf8"),
+        source,
+      );
     }
   } else {
     let i = 0;

--- a/packages/webdoc-parser/src/symbols-babel/index.js
+++ b/packages/webdoc-parser/src/symbols-babel/index.js
@@ -3,8 +3,9 @@
 // This file provides langJS and langTS integration, both of which use Babel to generate
 // symbols trees. These are registered in parse.js!
 
-import buildSymbolTree from "./build-symbol-tree";
 import type {LanguageConfig} from "../types/LanguageIntegration";
+import type {SourceFile} from "@webdoc/types";
+import buildSymbolTree from "./build-symbol-tree";
 
 // Plugins for plain JavaScript files
 const defaultPreset = [
@@ -44,15 +45,15 @@ const tsPreset = [
 
 export const langJS = {
   extensions: ["js", "jsx", "jsdoc"],
-  parse(file: string, fileName: string, config: LanguageConfig): Symbol {
+  parse(file: string, source: SourceFile, config: LanguageConfig): Symbol {
     // Flow is automatically handled!
-    return buildSymbolTree(file, fileName, config, flowPreset);
+    return buildSymbolTree(file, source, config, flowPreset);
   },
 };
 
 export const langTS = {
   extensions: ["ts", "tsx"],
-  parse(file: string, fileName: string, config: LanguageConfig): Symbol {
-    return buildSymbolTree(file, fileName, config, tsPreset);
+  parse(file: string, source: SourceFile, config: LanguageConfig): Symbol {
+    return buildSymbolTree(file, source, config, tsPreset);
   },
 };

--- a/packages/webdoc-parser/src/tag-parsers/parseProperty.js
+++ b/packages/webdoc-parser/src/tag-parsers/parseProperty.js
@@ -111,6 +111,7 @@ export function parseProperty(value: string, doc: $Shape<Doc>): PropertyTag {
     description,
     optional,
     scope: "default", // related-resolution doctree-mod will resolve this
+    loc: doc.loc,
   }));
 
   return {

--- a/packages/webdoc-parser/src/transformer/document-tree-modifiers.js
+++ b/packages/webdoc-parser/src/transformer/document-tree-modifiers.js
@@ -2,9 +2,10 @@
 
 import type {Doc, RootDoc} from "@webdoc/types";
 import modDiscoverMembers from "./mod-discover-members";
+import modPackageApi from "./mod-package-api";
 import modPrune from "./mod-prune";
-import modResolveMembers from "./mod-resolve-members";
 import modResolveMemberof from "./mod-resolve-memberof";
+import modResolveMembers from "./mod-resolve-members";
 import modResolveRelated from "./mod-resolve-related";
 import modSort from "./mod-sort-members";
 
@@ -130,6 +131,7 @@ registerDoctreeMod("ExtendsImplementsMixesResolution", STAGE_SYMBOLS_RESOLVED, m
 registerDoctreeMod("Prune", STAGE_FINISHED, modPrune);
 registerDoctreeMod("ClassMemberDiscovery", STAGE_FINISHED, modDiscoverMembers);
 registerDoctreeMod("Sort", STAGE_FINISHED, modSort);
+registerDoctreeMod("PackageApi", STAGE_FINISHED, modPackageApi);
 
 export default function mod(doctree) {
   for (let i = 0; i < installedMods.length; i++) {

--- a/packages/webdoc-parser/src/transformer/mod-package-api.js
+++ b/packages/webdoc-parser/src/transformer/mod-package-api.js
@@ -8,6 +8,10 @@ import type {Doc} from "@webdoc/types";
  * @param {Doc} doc - root of document tree
  */
 export default function packageApi(doc: Doc): void {
+  if (global.__TEST__) {
+    return;// packageApi does not run on testing environment
+  }
+
   if (doc.type !== "RootDoc") {
     const ppkg = doc.parent.loc ? doc.parent.loc.file.package : null;
     const pkg = doc.loc.file.package;

--- a/packages/webdoc-parser/src/transformer/mod-package-api.js
+++ b/packages/webdoc-parser/src/transformer/mod-package-api.js
@@ -1,0 +1,23 @@
+// @flow
+
+import type {Doc} from "@webdoc/types";
+
+/**
+ * Resolves each package's top-level API docs.
+ *
+ * @param {Doc} doc - root of document tree
+ */
+export default function packageApi(doc: Doc): void {
+  if (doc.type !== "RootDoc") {
+    const ppkg = doc.parent.loc ? doc.parent.loc.file.package : null;
+    const pkg = doc.loc.file.package;
+
+    if (pkg !== ppkg) {
+      pkg.api.push(doc);
+    }
+  }
+
+  doc.members.forEach((member) => {
+    packageApi(member);
+  });
+}

--- a/packages/webdoc-parser/src/types/LanguageIntegration.js
+++ b/packages/webdoc-parser/src/types/LanguageIntegration.js
@@ -1,11 +1,12 @@
 // @flow
 
+import type {SourceFile} from "@webdoc/types";
 import type {Symbol} from "./Symbol";
 
 // Language-integration definition - used for parsing code into a symbol-tree
 export type LanguageIntegration = {
   extensions: string[],
-  parse(file: string, fileName: string, config: LanguageConfig): Symbol
+  parse(file: string, source: SourceFile, config: LanguageConfig): Symbol
 };
 
 // Config for symbol-parsing

--- a/packages/webdoc-parser/src/types/Symbol.js
+++ b/packages/webdoc-parser/src/types/Symbol.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type {DocType, Param, Return} from "@webdoc/types";
+import type {DocType, Param, Return, SourceFile} from "@webdoc/types";
 import {parserLogger, tag} from "../Logger";
 import {CANONICAL_DELIMITER} from "../constants";
 import type {Node} from "@babel/types";
@@ -36,7 +36,8 @@ export type SymbolSignature = {
 export type SymbolLocation = {
   start: { line: number, column: number },
   end: { line: number, column: number },
-  fileName: string
+  fileName: string,
+  file: SourceFile
 }
 
 // This is a preliminary data-format that represents a documentable symbol.

--- a/packages/webdoc-parser/test/parse.js
+++ b/packages/webdoc-parser/test/parse.js
@@ -32,8 +32,10 @@ describe("@webdoc/parser.parse", function() {
   });
 
   it("should infer 'extends', 'implements' even if target is @memberof something else", function() {
-    const docs = parse(new Map(Object.entries({
-      "index.ts": `
+    const docs = parse([{
+      path: "index.ts",
+      package: {},
+      content: `
       /** @namespace NSName */
 
       /**
@@ -54,7 +56,7 @@ describe("@webdoc/parser.parse", function() {
       class ClassName extends SuperClassName implements InterfaceName {
 
       }
-    `})));
+    `}]);
 
     expect(docs.members.length).to.equal(2);
 
@@ -91,11 +93,11 @@ describe("@webdoc/parser.parse", function() {
       const settings = {};
     `;
 
-    const symtree = parse(new Map(Object.entries({
-      "file1.js": file1,
-      "file2.js": file2,
-      "main.js": main,
-    })));
+    const symtree = parse([
+      {content: file1, path: "file1.js", package: {}},
+      {content: file2, path: "file2.js", package: {}},
+      {content: main, path: "main.js", package: {}},
+    ]);
 
     expect(symtree.members.length).to.equal(1);
     expect(symtree.members[0].members.length).to.equal(2);

--- a/packages/webdoc-types/index.js.flow
+++ b/packages/webdoc-types/index.js.flow
@@ -1,317 +1,332 @@
 declare module "@webdoc/types" {
-    declare type DataType = (string|DocLink)[] & { template: string };
+  declare type DataType = (string|DocLink)[] & { template: string };
 
-    declare type ParserOpts = {
-      memberof?: string
-    };
+  declare type SourceFile = {
+    content?: string;
+    path: string;
+    package: PackageDoc;
+  };
 
-    declare type Param = {
-      identifier: string,
+  declare type ParserOpts = {
+    memberof?: string
+  };
+
+  declare type Param = {
+    identifier: string,
+    dataType: DataType,
+    description: string,
+    optional?: Boolean,
+    default?: string,
+    variadic?: boolean,
+  };
+
+  declare type Example = {
+    caption: string,
+    code: string
+  };
+
+  declare type SymbolLocation = {
+    start: { line: number, column: number },
+    end: { line: number, column: number },
+    fileName: string
+  }
+
+  declare type Typedef = {
+    of: string[],
+    alias: String,
+  };
+
+  declare type TypedDesc = {
+    dataType: DataType,
+    description: string,
+  };
+
+  declare type DocLink = Doc | string;
+
+  declare type Return = TypedDesc;
+
+  declare type DocType = "ClassDoc" | "FunctionDoc" | "MethodDoc" | "PropertyDoc" | "TypedefDoc" |
+      "NSDoc" | "EventDoc" | "EnumDoc"
+
+  declare type BaseDoc = {
+    name: string,
+    path: string,
+    stack: string[],
+    parent: Doc,
+    children: Doc[],
+    members: Doc[],
+    tags: Tag[],
+    brief: string,
+    description: string,
+    access: "public" | "protected" | "private",
+    authors: string[],
+    deprecated?: string,
+    extends?: DocLink[],
+    examples?: Example[],
+    fires?: [],
+    license?: string,
+    loc?: SourceLocation,
+    scope: "static" | "instance" | "inner" | "default",
+    see?: DocLink[],
+    since?: string,
+    todo?: string[],
+    throws?: DocLink[],
+    version: "alpha" | "beta" | "internal" | "public" | "deprecated",
+    type: "ClassDoc" | "FunctionDoc" | "MethodDoc" | "ObjectDoc" | "RootDoc" | "TypedefDoc",
+    parserOpts?: ParserOpts
+  };
+
+  declare type Doc = BaseDoc | ClassDoc | ObjectDoc | FunctionDoc | MethodDoc | PropertyDoc
+      | TypedefDoc | NSDoc | EventDoc;
+
+  declare type RootDoc = {
+    ...Doc,
+    packages: PackageDoc[],
+    type: "RootDoc"
+  };
+
+  declare type ClassDoc = {
+    ...BaseDoc,
+    params?: Param[],
+    implements?: DocLink[],
+    mixes?: [],
+    type: "ClassDoc"
+  };
+
+  declare type EnumDoc = {
+    ...BaseDoc,
+    type: "EnumDoc"
+  };
+
+  declare type EventDoc = {
+    ...BaseDoc,
+    eventType: string,
+    params?: Param[],
+    type: "EventDoc"
+  };
+
+  declare type FunctionDoc = {
+    ...BaseDoc,
+    params: Param[],
+    returns: Return[],
+    type: "FunctionDoc"
+  };
+
+  declare type MethodDoc = {
+    ...BaseDoc,
+    params: Param[],
+    returns: Return[],
+    inherited: boolean,
+    inherits: MethodDoc,
+    overrides: boolean,
+    type: "MethodDoc"
+  };
+
+  declare type MixinDoc = {
+    ...BaseDoc,
+    mixes?: [],
+    type: "MixinDoc"
+  };
+
+  declare type NSDoc = {
+    ...Doc,
+    type: "NSDoc"
+  };
+
+  declare type ObjectDoc = {
+    ...Doc,
+    implements?: DocLink[],
+    mixes?: [],
+    type: "ObjectDoc"
+  };
+
+  declare type PackageDoc = {
+    ...Doc,
+    api: Doc[],
+    location: string,
+    metadata: Object,
+    type: "PackageDoc"
+  };
+
+  declare type PropertyDoc = {
+    ...Doc,
+    constant?: boolean,
+    dataType?: DataType,
+    dataValue?: string, // Enumerations/constants
+    defaultValue?: string,
+    inherited?: boolean,
+    inherits?: PropertyDoc,
+    optional?: boolean,
+    readonly?: boolean,
+    type: "PropertyDoc"
+  };
+
+  declare type Tutorial = {
+    ...BaseDoc,
+    title: string,
+    contents: string,
+    type: "TutorialDoc"
+  };
+
+  declare type TypedefDoc = {
+    ...Doc,
+    of: [string],
+    alias: string,
+    type: "TypedefDoc",
+    implements: DocLink[]
+  };
+
+  declare type BaseTag = {
+    name: string,
+    value: string,
+    type: "link" | "param" | "return" | "throws"
+  };
+
+  declare type Tag = AccessTag | BaseTag | DeprecatedTag | ExampleTag | ExtendsTag | TypedTag |
+      ParamTag | ReturnTag | MemberTag | ImplementsTag | MixesTag |
+      ThrowsTag | PrivateTag | PropertyTag | ProtectedTag | PublicTag
+
+  declare type AccessTag = {
+    ...BaseTag,
+    access: "public" | "protected" | "private",
+    type: "AccessTag"
+  };
+
+  declare type DeprecatedTag = {
+    ...BaseTag,
+    deprecated: string | boolean,
+    type: "DeprecatedTag"
+  };
+
+  declare type EventTag = {
+    ...BaseTag,
+    event: string,
+    type: "EventTag"
+  };
+
+  declare type ExampleTag = {
+    ...BaseTag,
+    code: string,
+    type: "ExampleTag"
+  };
+
+  declare type ExtendsTag = {
+    ...BaseTag,
+    type: "ExtendsTag"
+  };
+
+  declare type FiresTag = {
+    ...BaseTag,
+    event: string,
+    type: "FiresTag"
+  };
+
+  declare type ImplementsTag = {
+    ...BaseTag,
+    type: "ImplementsTag"
+  };
+
+  declare type InnerTag = {
+    ...BaseTag,
+    type: "InnerTag"
+  };
+
+  declare type InstanceTag = {
+    ...BaseTag,
+    type: "InstanceTag"
+  };
+
+  declare type MixesTag = {
+    ...BaseTag,
+    type: "MixesTag"
+  };
+
+  declare type MemberTag = {
+    ...BaseTag,
+    dataType: DataType
+  };
+
+  declare type MemberofTag = {
+    ...BaseTag,
+    scope: string,
+    type: "MemberofTag"
+  };
+
+  declare type NameTag = {
+    ...BaseTag,
+    alias: string,
+    type: "NameTag"
+  };
+
+  declare type ParamTag = {
+    ...TypedTag,
+    identifier: string,
+    referred: string,
+    description: string,
+    optional?: Boolean,
+    default?: string,
+    variadic?: boolean,
+    type: "ParamTag"
+  };
+
+  declare type ReturnTag = {
+    ...TypedTag,
+    type: "ReturnTag"
+  };
+
+  declare type StaticTag = {
+    ...BaseTag,
+    type: "StaticTag"
+  };
+
+  declare type ScopeTag = {
+    ...BaseTag,
+    scope: "static" | "instance" | "inner",
+    type: "ScopeTag"
+  };
+
+  declare type ThrowsTag = {
+    ...TypedTag,
+    type: "ThrowsTag"
+  };
+
+  declare type TypeTag = {
+    ...BaseTag,
+    dataType: DataType,
+    type: "TypeTag"
+  };
+
+  declare type TypedTag = {
+    ...BaseTag,
+    dataType: DataType,
+    description: string,
+  };
+
+  declare type TypedefTag = {
+    dataType: DataType,
+    alias: String,
+    type: "TypedefTag"
+  };
+
+  declare type PrivateTag = {
+    ...BaseTag,
+    type: "PrivateTag"
+  };
+
+  declare type PropertyTag = {
+      ...BaseTag,
       dataType: DataType,
       description: string,
-      optional?: Boolean,
-      default?: string,
-      variadic?: boolean,
-    };
+      type: "PropertyTag"
+  };
 
-    declare type Example = {
-      caption: string,
-      code: string
-    };
+  declare type ProtectedTag = {
+    ...BaseTag,
+    type: "ProtectedTag"
+  };
 
-    declare type SymbolLocation = {
-      start: { line: number, column: number },
-      end: { line: number, column: number },
-      fileName: string
-    }
-
-    declare type Typedef = {
-      of: string[],
-      alias: String,
-    };
-
-    declare type TypedDesc = {
-      dataType: DataType,
-      description: string,
-    };
-
-    declare type DocLink = Doc | string;
-
-    declare type Return = TypedDesc;
-
-    declare type DocType = "ClassDoc" | "FunctionDoc" | "MethodDoc" | "PropertyDoc" | "TypedefDoc" |
-        "NSDoc" | "EventDoc" | "EnumDoc"
-
-    declare type BaseDoc = {
-      name: string,
-      path: string,
-      stack: string[],
-      parent: Doc,
-      children: Doc[],
-      members: Doc[],
-      tags: Tag[],
-      brief: string,
-      description: string,
-      access: "public" | "protected" | "private",
-      authors: string[],
-      deprecated?: string,
-      extends?: DocLink[],
-      examples?: Example[],
-      fires?: [],
-      license?: string,
-      loc?: SourceLocation,
-      scope: "static" | "instance" | "inner" | "default",
-      see?: DocLink[],
-      since?: string,
-      todo?: string[],
-      throws?: DocLink[],
-      version: "alpha" | "beta" | "internal" | "public" | "deprecated",
-      type: "ClassDoc" | "FunctionDoc" | "MethodDoc" | "ObjectDoc" | "RootDoc" | "TypedefDoc",
-      parserOpts?: ParserOpts
-    };
-
-    declare type Doc = BaseDoc | ClassDoc | ObjectDoc | FunctionDoc | MethodDoc | PropertyDoc
-        | TypedefDoc | NSDoc | EventDoc;
-
-    declare type RootDoc = {
-      ...Doc,
-      type: "RootDoc"
-    };
-
-    declare type ClassDoc = {
-      ...BaseDoc,
-      params?: Param[],
-      implements?: DocLink[],
-      mixes?: [],
-      type: "ClassDoc"
-    };
-
-    declare type EnumDoc = {
-      ...BaseDoc,
-      type: "EnumDoc"
-    };
-
-    declare type EventDoc = {
-      ...BaseDoc,
-      eventType: string,
-      params?: Param[],
-      type: "EventDoc"
-    };
-
-    declare type FunctionDoc = {
-      ...BaseDoc,
-      params: Param[],
-      returns: Return[],
-      type: "FunctionDoc"
-    };
-
-    declare type MethodDoc = {
-      ...BaseDoc,
-      params: Param[],
-      returns: Return[],
-      inherited: boolean,
-      inherits: MethodDoc,
-      overrides: boolean,
-      type: "MethodDoc"
-    };
-
-    declare type MixinDoc = {
-      ...BaseDoc,
-      mixes?: [],
-      type: "MixinDoc"
-    };
-
-    declare type NSDoc = {
-      ...Doc,
-      type: "NSDoc"
-    };
-
-    declare type ObjectDoc = {
-      ...Doc,
-      implements?: DocLink[],
-      mixes?: [],
-      type: "ObjectDoc"
-    };
-
-    declare type PropertyDoc = {
-      ...Doc,
-      constant?: boolean,
-      dataType?: DataType,
-      dataValue?: string, // Enumerations/constants
-      defaultValue?: string,
-      inherited?: boolean,
-      inherits?: PropertyDoc,
-      optional?: boolean,
-      readonly?: boolean,
-      type: "PropertyDoc"
-    };
-
-    declare type Tutorial = {
-      ...BaseDoc,
-      title: string,
-      contents: string,
-      type: "TutorialDoc"
-    };
-
-    declare type TypedefDoc = {
-      ...Doc,
-      of: [string],
-      alias: string,
-      type: "TypedefDoc",
-      implements: DocLink[]
-    };
-
-    declare type BaseTag = {
-      name: string,
-      value: string,
-      type: "link" | "param" | "return" | "throws"
-    };
-
-    declare type Tag = AccessTag | BaseTag | DeprecatedTag | ExampleTag | ExtendsTag | TypedTag |
-        ParamTag | ReturnTag | MemberTag | ImplementsTag | MixesTag |
-        ThrowsTag | PrivateTag | PropertyTag | ProtectedTag | PublicTag
-
-    declare type AccessTag = {
-      ...BaseTag,
-      access: "public" | "protected" | "private",
-      type: "AccessTag"
-    };
-
-    declare type DeprecatedTag = {
-      ...BaseTag,
-      deprecated: string | boolean,
-      type: "DeprecatedTag"
-    };
-
-    declare type EventTag = {
-      ...BaseTag,
-      event: string,
-      type: "EventTag"
-    };
-
-    declare type ExampleTag = {
-      ...BaseTag,
-      code: string,
-      type: "ExampleTag"
-    };
-
-    declare type ExtendsTag = {
-      ...BaseTag,
-      type: "ExtendsTag"
-    };
-
-    declare type FiresTag = {
-      ...BaseTag,
-      event: string,
-      type: "FiresTag"
-    };
-
-    declare type ImplementsTag = {
-      ...BaseTag,
-      type: "ImplementsTag"
-    };
-
-    declare type InnerTag = {
-      ...BaseTag,
-      type: "InnerTag"
-    };
-
-    declare type InstanceTag = {
-      ...BaseTag,
-      type: "InstanceTag"
-    };
-
-    declare type MixesTag = {
-      ...BaseTag,
-      type: "MixesTag"
-    };
-
-    declare type MemberTag = {
-      ...BaseTag,
-      dataType: DataType
-    };
-
-    declare type MemberofTag = {
-      ...BaseTag,
-      scope: string,
-      type: "MemberofTag"
-    };
-
-    declare type NameTag = {
-      ...BaseTag,
-      alias: string,
-      type: "NameTag"
-    };
-
-    declare type ParamTag = {
-      ...TypedTag,
-      identifier: string,
-      referred: string,
-      description: string,
-      optional?: Boolean,
-      default?: string,
-      variadic?: boolean,
-      type: "ParamTag"
-    };
-
-    declare type ReturnTag = {
-      ...TypedTag,
-      type: "ReturnTag"
-    };
-
-    declare type StaticTag = {
-      ...BaseTag,
-      type: "StaticTag"
-    };
-
-    declare type ScopeTag = {
-      ...BaseTag,
-      scope: "static" | "instance" | "inner",
-      type: "ScopeTag"
-    };
-
-    declare type ThrowsTag = {
-      ...TypedTag,
-      type: "ThrowsTag"
-    };
-
-    declare type TypeTag = {
-      ...BaseTag,
-      dataType: DataType,
-      type: "TypeTag"
-    };
-
-    declare type TypedTag = {
-      ...BaseTag,
-      dataType: DataType,
-      description: string,
-    };
-
-    declare type TypedefTag = {
-      dataType: DataType,
-      alias: String,
-      type: "TypedefTag"
-    };
-
-    declare type PrivateTag = {
-      ...BaseTag,
-      type: "PrivateTag"
-    };
-
-    declare type PropertyTag = {
-        ...BaseTag,
-        dataType: DataType,
-        description: string,
-        type: "PropertyTag"
-    };
-
-    declare type ProtectedTag = {
-      ...BaseTag,
-      type: "ProtectedTag"
-    };
-
-    declare type PublicTag = {
-      ...BaseTag,
-      type: "PublicTag"
-    };
+  declare type PublicTag = {
+    ...BaseTag,
+    type: "PublicTag"
+  };
 }

--- a/packages/webdoc-types/index.js.flow
+++ b/packages/webdoc-types/index.js.flow
@@ -28,6 +28,7 @@ declare module "@webdoc/types" {
   declare type SymbolLocation = {
     start: { line: number, column: number },
     end: { line: number, column: number },
+    file: SourceFile,
     fileName: string
   }
 
@@ -65,7 +66,7 @@ declare module "@webdoc/types" {
     examples?: Example[],
     fires?: [],
     license?: string,
-    loc?: SourceLocation,
+    loc?: SymbolLocation,
     scope: "static" | "instance" | "inner" | "default",
     see?: DocLink[],
     since?: string,

--- a/scripts/configureWebdocTesting.js
+++ b/scripts/configureWebdocTesting.js
@@ -3,6 +3,8 @@
 const {applyDefaultLangConfig} = require("../packages/webdoc-parser/lib/parse.js");
 const {initLogger: initParserLogger} = require("../packages/webdoc-parser/lib/Logger");
 
+global.__TEST__ = true;
+
 // Don't need to write a documentation comment above each symbol in unit-tests now
 applyDefaultLangConfig({
   reportUndocumented: true,

--- a/webdoc.conf.json
+++ b/webdoc.conf.json
@@ -1,0 +1,20 @@
+{
+    "source": {
+        "includePattern": [
+          "packages/webdoc-cli/src/**/*.js",
+          "packages/webdoc-externalize/src/**/*.js",
+          "packages/webdoc-model/src/**/*.js",
+          "packages/webdoc-parser/src/**/*.js"
+        ]
+    },
+    "plugins": [
+      "plugins/markdown"
+    ],
+    "opts": {
+      "destination": "example/next-docs"
+    },
+    "template": {
+      "readme": "./README.md",
+      "outputSourceFiles": true
+    }
+}


### PR DESCRIPTION
# Brief 🎢 

This PR would introduce multi-package support in webdoc. It adds the `SourceFile` API to the documentation model.

## SourceFile

webdoc now stores information about each source file in the codebase. Each source file points to a `PackageDoc`.

## PackageDoc

Each `PackageDoc` has an `api` field that stores the top-level exported members. These are inferred in the doc-tree-modifier packageApi.

## Template

The default template uses a special traversal loop to stay within each package in multi-package mode to generate the api explorer.