### PR TITLE
Support Alternative Link Formats

### DIFF
--- a/packages/webdoc-template-library/src/pipeline-elements/TemplateTagsResolver.js
+++ b/packages/webdoc-template-library/src/pipeline-elements/TemplateTagsResolver.js
@@ -3,7 +3,7 @@
 import type {TemplatePipelineElement} from "../TemplatePipelineElement";
 import {SymbolLinks} from "../SymbolLinks";
 
-const LINK_PATTERN = /{@link ([^}]*)}/g;
+const LINK_PATTERN = /{@link ([^|\s}]*)([\s|])?([^}]*)}/g;
 
 /**
  * Resolves the following types of tags:
@@ -34,10 +34,8 @@ export class TemplateTagsResolver implements TemplatePipelineElement<{}> {
 
     while ((linkMatch = linkPattern.exec(input)) !== null) {
       const linkTextMatch = matchTextPrefix(input, linkMatch.index);
-
-      const parts = linkMatch[1].split(/\s*?[|\s]\s*?/);
-      const link = parts[0];
-      const linkName = parts[1];
+      const link = linkMatch[1];
+      const linkName = linkMatch[3];
       const linkText = linkTextMatch ? linkTextMatch[0].slice(1, -1) : (linkName || link);
 
       let replaced;

--- a/packages/webdoc-template-library/src/pipeline-elements/TemplateTagsResolver.js
+++ b/packages/webdoc-template-library/src/pipeline-elements/TemplateTagsResolver.js
@@ -37,7 +37,7 @@ export class TemplateTagsResolver implements TemplatePipelineElement<{}> {
 
       const parts = linkMatch[1].split(/\s*?[|\s]\s*?/);
       const link = parts[0];
-      const linkName = parts[0];
+      const linkName = parts[1];
       const linkText = linkTextMatch ? linkTextMatch[0].slice(1, -1) : (linkName || link);
 
       let replaced;

--- a/packages/webdoc-template-library/src/pipeline-elements/TemplateTagsResolver.js
+++ b/packages/webdoc-template-library/src/pipeline-elements/TemplateTagsResolver.js
@@ -35,8 +35,11 @@ export class TemplateTagsResolver implements TemplatePipelineElement<{}> {
     while ((linkMatch = linkPattern.exec(input)) !== null) {
       const linkTextMatch = matchTextPrefix(input, linkMatch.index);
 
-      const link = linkMatch[1];
-      const linkText = linkTextMatch ? linkTextMatch[0].slice(1, -1) : link;
+      const parts = linkMatch[1].split(/\s*?[|\s]\s*?/);
+      const link = parts[0];
+      const linkName = parts[0];
+      const linkText = linkTextMatch ? linkTextMatch[0].slice(1, -1) : (linkName || link);
+
       let replaced;
 
       if (isValidUrl(link)) {

--- a/packages/webdoc-template-library/test/pipeline-elements/TemplateTagsResolver.js
+++ b/packages/webdoc-template-library/test/pipeline-elements/TemplateTagsResolver.js
@@ -12,28 +12,30 @@ describe("@webdoc/template-library.TemplateTagsResolver", function() {
 
   it("{@link <DOC_PATH> <NAME>}", function() {
     expect(mockTagsResolver.runLink("--{@link <DOC_PATH> <NAME>}--"))
-      .to.equal("--<DOC_PATH>--");
-  });
-
-  it("{@link <DOC_PATH>   <NAME>}", function() {
-    expect(mockTagsResolver.runLink("--{@link <DOC_PATH>   <NAME>}--"))
-      .to.equal("--<DOC_PATH>--");
+      .to.equal("--<NAME>--");
   });
 
   it("{@link <DOC_PATH>|<NAME>}", function() {
     expect(mockTagsResolver.runLink("--{@link <DOC_PATH>|<NAME>}--"))
-      .to.equal("--<DOC_PATH>--");
-  });
-
-  it("{@link <DOC_PATH> | <NAME>}", function() {
-    expect(mockTagsResolver.runLink("--{@link <DOC_PATH> | <NAME>}--"))
-      .to.equal("--<DOC_PATH>--");
+      .to.equal("--<NAME>--");
   });
 
   it("{@link https://github.com/webdoc-js/webdoc}", function() {
     expect(mockTagsResolver.runLink("--{@link https://github.com/webdoc-js/webdoc}--"))
       .to.equal("--<a href=\"https://github.com/webdoc-js/webdoc\">" +
         "https://github.com/webdoc-js/webdoc</a>--");
+  });
+
+  it("{@link https://github.com/webdoc-js/webdoc|LINK_NAME}", function() {
+    expect(mockTagsResolver.runLink("--{@link https://github.com/webdoc-js/webdoc|LINK_NAME}--"))
+      .to.equal("--<a href=\"https://github.com/webdoc-js/webdoc\">" +
+        "LINK_NAME</a>--");
+  });
+
+  it("{@link https://github.com/webdoc-js/webdoc LINK NAME}", function() {
+    expect(mockTagsResolver.runLink("--{@link https://github.com/webdoc-js/webdoc LINK NAME}--"))
+      .to.equal("--<a href=\"https://github.com/webdoc-js/webdoc\">" +
+        "LINK NAME</a>--");
   });
 
   it("[LINK_TEXT]{@link DOC_PATH}", function() {

--- a/packages/webdoc-template-library/test/pipeline-elements/TemplateTagsResolver.js
+++ b/packages/webdoc-template-library/test/pipeline-elements/TemplateTagsResolver.js
@@ -10,6 +10,26 @@ describe("@webdoc/template-library.TemplateTagsResolver", function() {
       .to.equal("--<DOC_PATH>--");
   });
 
+  it("{@link <DOC_PATH> <NAME>}", function() {
+    expect(mockTagsResolver.runLink("--{@link <DOC_PATH> <NAME>}--"))
+      .to.equal("--<DOC_PATH>--");
+  });
+
+  it("{@link <DOC_PATH>   <NAME>}", function() {
+    expect(mockTagsResolver.runLink("--{@link <DOC_PATH>   <NAME>}--"))
+      .to.equal("--<DOC_PATH>--");
+  });
+
+  it("{@link <DOC_PATH>|<NAME>}", function() {
+    expect(mockTagsResolver.runLink("--{@link <DOC_PATH>|<NAME>}--"))
+      .to.equal("--<DOC_PATH>--");
+  });
+
+  it("{@link <DOC_PATH> | <NAME>}", function() {
+    expect(mockTagsResolver.runLink("--{@link <DOC_PATH> | <NAME>}--"))
+      .to.equal("--<DOC_PATH>--");
+  });
+
   it("{@link https://github.com/webdoc-js/webdoc}", function() {
     expect(mockTagsResolver.runLink("--{@link https://github.com/webdoc-js/webdoc}--"))
       .to.equal("--<a href=\"https://github.com/webdoc-js/webdoc\">" +


### PR DESCRIPTION
This PR adds support for alternative link formats. Example of where this is [used in PixiJS](http://pixijs.download/dev/docs/PIXI.BitmapFont.html#from).

Reference: https://jsdoc.app/tags-inline-link.html

* `{@link namepathOrURL}` ✅ 
* `[link text]{@link namepathOrURL}` ✅ 
* `{@link namepathOrURL|link text}` ❌    **Added Support**
* `{@link namepathOrURL link text (after the first space)}` ❌    **Added Support**
