### PR TITLE
[Feature]: Upgraded linker API

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,12 +1,13 @@
 dependencies:
-  '@babel/cli': 7.10.5
+  '@babel/cli': 7.10.5_@babel+core@7.11.6
+  '@babel/core': 7.11.6
   '@babel/parser': 7.11.4
-  '@babel/plugin-proposal-class-properties': 7.10.4
-  '@babel/plugin-transform-flow-comments': 7.10.4
-  '@babel/preset-env': 7.11.0
-  '@babel/preset-flow': 7.10.4
-  '@babel/preset-react': 7.10.4
-  '@babel/register': 7.10.5
+  '@babel/plugin-proposal-class-properties': 7.10.4_@babel+core@7.11.6
+  '@babel/plugin-transform-flow-comments': 7.10.4_@babel+core@7.11.6
+  '@babel/preset-env': 7.11.0_@babel+core@7.11.6
+  '@babel/preset-flow': 7.10.4_@babel+core@7.11.6
+  '@babel/preset-react': 7.10.4_@babel+core@7.11.6
+  '@babel/register': 7.10.5_@babel+core@7.11.6
   '@babel/traverse': 7.9.5
   '@babel/types': 7.9.5
   '@material-ui/core': 4.11.0_react-dom@16.13.1+react@16.13.1
@@ -27,7 +28,7 @@ dependencies:
   '@rush-temp/types': 'file:projects/types.tgz'
   '@rushstack/eslint-patch': 1.0.3
   babel-eslint: 10.1.0_eslint@6.8.0
-  babel-loader: 8.1.0_webpack@4.44.1
+  babel-loader: 8.1.0_5a36cfe3630aa5e4fa0785cefae272b5
   bluebird: 3.7.2
   catharsis: 0.8.11
   chai: 4.2.0
@@ -50,7 +51,7 @@ dependencies:
   git-branch: 2.0.1
   globby: 11.0.0
   gulp: 4.0.2
-  gulp-babel: 8.0.0
+  gulp-babel: 8.0.0_@babel+core@7.11.6
   gulp-util: 3.0.8
   jsdoc: 3.6.4
   klaw-sync: 6.0.0
@@ -61,7 +62,6 @@ dependencies:
   mini-css-extract-plugin: 0.9.0_webpack@4.44.1
   missionlog: 1.6.0
   mocha: 7.2.0
-  nanoid: 3.1.12
   object.fromentries: 2.0.2
   open-sans-fonts: 1.6.2
   optimize-css-assets-webpack-plugin: 5.0.3_webpack@4.44.1
@@ -79,8 +79,9 @@ dependencies:
   yargs: 15.3.1
 lockfileVersion: 5.1
 packages:
-  /@babel/cli/7.10.5:
+  /@babel/cli/7.10.5_@babel+core@7.11.4:
     dependencies:
+      '@babel/core': 7.11.4
       commander: 4.1.1
       convert-source-map: 1.7.0
       fs-readdir-recursive: 1.1.0
@@ -97,9 +98,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-j9H9qSf3kLdM0Ao3aGPbGZ73mEA9XazuupcS6cDGWuiyAcANoguhP0r2Lx32H5JGw4sSSoHG3x/mxVnHgvOoyA==
-  /@babel/cli/7.10.5_@babel+core@7.11.4:
+  /@babel/cli/7.10.5_@babel+core@7.11.6:
     dependencies:
-      '@babel/core': 7.11.4
+      '@babel/core': 7.11.6
       commander: 4.1.1
       convert-source-map: 1.7.0
       fs-readdir-recursive: 1.1.0
@@ -220,18 +221,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-5nPcIZ7+KKDxT1427oBivl9V9YTal7qk0diccnh7RrcgrT/pGFOjgGw1dgryyx1GvHEpXVfoDF6Ak3rTiWh8Rg==
-  /@babel/helper-compilation-targets/7.10.4:
-    dependencies:
-      '@babel/compat-data': 7.11.0
-      browserslist: 4.14.0
-      invariant: 2.2.4
-      levenary: 1.1.1
-      semver: 5.7.1
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    resolution:
-      integrity: sha512-a3rYhlsGV0UHNDvrtOXBg8/OpfV0OKTkxKPzIplS1zpx7CygDcWWxckxZeDd3gzPzC4kUT0A4nVFDK0wGMh4MQ==
   /@babel/helper-compilation-targets/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/compat-data': 7.11.0
@@ -245,19 +234,19 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-a3rYhlsGV0UHNDvrtOXBg8/OpfV0OKTkxKPzIplS1zpx7CygDcWWxckxZeDd3gzPzC4kUT0A4nVFDK0wGMh4MQ==
-  /@babel/helper-create-class-features-plugin/7.10.5:
+  /@babel/helper-compilation-targets/7.10.4_@babel+core@7.11.6:
     dependencies:
-      '@babel/helper-function-name': 7.10.4
-      '@babel/helper-member-expression-to-functions': 7.11.0
-      '@babel/helper-optimise-call-expression': 7.10.4
-      '@babel/helper-plugin-utils': 7.10.4
-      '@babel/helper-replace-supers': 7.10.4
-      '@babel/helper-split-export-declaration': 7.11.0
+      '@babel/compat-data': 7.11.0
+      '@babel/core': 7.11.6
+      browserslist: 4.14.0
+      invariant: 2.2.4
+      levenary: 1.1.1
+      semver: 5.7.1
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
-      integrity: sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==
+      integrity: sha512-a3rYhlsGV0UHNDvrtOXBg8/OpfV0OKTkxKPzIplS1zpx7CygDcWWxckxZeDd3gzPzC4kUT0A4nVFDK0wGMh4MQ==
   /@babel/helper-create-class-features-plugin/7.10.5_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -272,8 +261,23 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==
-  /@babel/helper-create-regexp-features-plugin/7.10.4:
+  /@babel/helper-create-class-features-plugin/7.10.5_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
+      '@babel/helper-function-name': 7.10.4
+      '@babel/helper-member-expression-to-functions': 7.11.0
+      '@babel/helper-optimise-call-expression': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-replace-supers': 7.10.4
+      '@babel/helper-split-export-declaration': 7.11.0
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    resolution:
+      integrity: sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==
+  /@babel/helper-create-regexp-features-plugin/7.10.4_@babel+core@7.11.4:
+    dependencies:
+      '@babel/core': 7.11.4
       '@babel/helper-annotate-as-pure': 7.10.4
       '@babel/helper-regex': 7.10.5
       regexpu-core: 4.7.0
@@ -282,9 +286,9 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-2/hu58IEPKeoLF45DBwx3XFqsbCXmkdAay4spVr2x0jYgRxrSNp+ePwvSsy9g6YSaNDcKIQVPXk1Ov8S2edk2g==
-  /@babel/helper-create-regexp-features-plugin/7.10.4_@babel+core@7.11.4:
+  /@babel/helper-create-regexp-features-plugin/7.10.4_@babel+core@7.11.6:
     dependencies:
-      '@babel/core': 7.11.4
+      '@babel/core': 7.11.6
       '@babel/helper-annotate-as-pure': 7.10.4
       '@babel/helper-regex': 7.10.5
       regexpu-core: 4.7.0
@@ -447,16 +451,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==
-  /@babel/plugin-proposal-async-generator-functions/7.10.5:
-    dependencies:
-      '@babel/helper-plugin-utils': 7.10.4
-      '@babel/helper-remap-async-to-generator': 7.11.4
-      '@babel/plugin-syntax-async-generators': 7.8.4
-    dev: false
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-cNMCVezQbrRGvXJwm9fu/1sJj9bHdGAgKodZdLqOQIpfoH3raqmRPBM17+lh7CzhiKRRBrGtZL9WcjxSoGYUSg==
   /@babel/plugin-proposal-async-generator-functions/7.10.5_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -468,15 +462,17 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-cNMCVezQbrRGvXJwm9fu/1sJj9bHdGAgKodZdLqOQIpfoH3raqmRPBM17+lh7CzhiKRRBrGtZL9WcjxSoGYUSg==
-  /@babel/plugin-proposal-class-properties/7.10.4:
+  /@babel/plugin-proposal-async-generator-functions/7.10.5_@babel+core@7.11.6:
     dependencies:
-      '@babel/helper-create-class-features-plugin': 7.10.5
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-remap-async-to-generator': 7.11.4
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.11.6
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==
+      integrity: sha512-cNMCVezQbrRGvXJwm9fu/1sJj9bHdGAgKodZdLqOQIpfoH3raqmRPBM17+lh7CzhiKRRBrGtZL9WcjxSoGYUSg==
   /@babel/plugin-proposal-class-properties/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -487,15 +483,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==
-  /@babel/plugin-proposal-dynamic-import/7.10.4:
+  /@babel/plugin-proposal-class-properties/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
+      '@babel/helper-create-class-features-plugin': 7.10.5_@babel+core@7.11.6
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-dynamic-import': 7.8.3
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-up6oID1LeidOOASNXgv/CFbgBqTuKJ0cJjz6An5tWD+NVBNlp3VNSBxv2ZdU7SYl3NxJC7agAQDApZusV6uFwQ==
+      integrity: sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==
   /@babel/plugin-proposal-dynamic-import/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -506,15 +503,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-up6oID1LeidOOASNXgv/CFbgBqTuKJ0cJjz6An5tWD+NVBNlp3VNSBxv2ZdU7SYl3NxJC7agAQDApZusV6uFwQ==
-  /@babel/plugin-proposal-export-namespace-from/7.10.4:
+  /@babel/plugin-proposal-dynamic-import/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.11.6
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-aNdf0LY6/3WXkhh0Fdb6Zk9j1NMD8ovj3F6r0+3j837Pn1S1PdNtcwJ5EG9WkVPNHPxyJDaxMaAOVq4eki0qbg==
+      integrity: sha512-up6oID1LeidOOASNXgv/CFbgBqTuKJ0cJjz6An5tWD+NVBNlp3VNSBxv2ZdU7SYl3NxJC7agAQDApZusV6uFwQ==
   /@babel/plugin-proposal-export-namespace-from/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -525,15 +523,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-aNdf0LY6/3WXkhh0Fdb6Zk9j1NMD8ovj3F6r0+3j837Pn1S1PdNtcwJ5EG9WkVPNHPxyJDaxMaAOVq4eki0qbg==
-  /@babel/plugin-proposal-json-strings/7.10.4:
+  /@babel/plugin-proposal-export-namespace-from/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-json-strings': 7.8.3
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.11.6
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-fCL7QF0Jo83uy1K0P2YXrfX11tj3lkpN7l4dMv9Y9VkowkhkQDwFHFd8IiwyK5MZjE8UpbgokkgtcReH88Abaw==
+      integrity: sha512-aNdf0LY6/3WXkhh0Fdb6Zk9j1NMD8ovj3F6r0+3j837Pn1S1PdNtcwJ5EG9WkVPNHPxyJDaxMaAOVq4eki0qbg==
   /@babel/plugin-proposal-json-strings/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -544,15 +543,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-fCL7QF0Jo83uy1K0P2YXrfX11tj3lkpN7l4dMv9Y9VkowkhkQDwFHFd8IiwyK5MZjE8UpbgokkgtcReH88Abaw==
-  /@babel/plugin-proposal-logical-assignment-operators/7.11.0:
+  /@babel/plugin-proposal-json-strings/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.11.6
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-/f8p4z+Auz0Uaf+i8Ekf1iM7wUNLcViFUGiPxKeXvxTSl63B875YPiVdUDdem7hREcI0E0kSpEhS8tF5RphK7Q==
+      integrity: sha512-fCL7QF0Jo83uy1K0P2YXrfX11tj3lkpN7l4dMv9Y9VkowkhkQDwFHFd8IiwyK5MZjE8UpbgokkgtcReH88Abaw==
   /@babel/plugin-proposal-logical-assignment-operators/7.11.0_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -563,15 +563,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-/f8p4z+Auz0Uaf+i8Ekf1iM7wUNLcViFUGiPxKeXvxTSl63B875YPiVdUDdem7hREcI0E0kSpEhS8tF5RphK7Q==
-  /@babel/plugin-proposal-nullish-coalescing-operator/7.10.4:
+  /@babel/plugin-proposal-logical-assignment-operators/7.11.0_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.11.6
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-wq5n1M3ZUlHl9sqT2ok1T2/MTt6AXE0e1Lz4WzWBr95LsAZ5qDXe4KnFuauYyEyLiohvXFMdbsOTMyLZs91Zlw==
+      integrity: sha512-/f8p4z+Auz0Uaf+i8Ekf1iM7wUNLcViFUGiPxKeXvxTSl63B875YPiVdUDdem7hREcI0E0kSpEhS8tF5RphK7Q==
   /@babel/plugin-proposal-nullish-coalescing-operator/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -582,15 +583,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-wq5n1M3ZUlHl9sqT2ok1T2/MTt6AXE0e1Lz4WzWBr95LsAZ5qDXe4KnFuauYyEyLiohvXFMdbsOTMyLZs91Zlw==
-  /@babel/plugin-proposal-numeric-separator/7.10.4:
+  /@babel/plugin-proposal-nullish-coalescing-operator/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-numeric-separator': 7.10.4
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.11.6
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-73/G7QoRoeNkLZFxsoCCvlg4ezE4eM+57PnOqgaPOozd5myfj7p0muD1mRVJvbUWbOzD+q3No2bWbaKy+DJ8DA==
+      integrity: sha512-wq5n1M3ZUlHl9sqT2ok1T2/MTt6AXE0e1Lz4WzWBr95LsAZ5qDXe4KnFuauYyEyLiohvXFMdbsOTMyLZs91Zlw==
   /@babel/plugin-proposal-numeric-separator/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -601,16 +603,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-73/G7QoRoeNkLZFxsoCCvlg4ezE4eM+57PnOqgaPOozd5myfj7p0muD1mRVJvbUWbOzD+q3No2bWbaKy+DJ8DA==
-  /@babel/plugin-proposal-object-rest-spread/7.11.0:
+  /@babel/plugin-proposal-numeric-separator/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3
-      '@babel/plugin-transform-parameters': 7.10.5
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.11.6
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-wzch41N4yztwoRw0ak+37wxwJM2oiIiy6huGCoqkvSTA9acYWcPfn9Y4aJqmFFJ70KTJUu29f3DQ43uJ9HXzEA==
+      integrity: sha512-73/G7QoRoeNkLZFxsoCCvlg4ezE4eM+57PnOqgaPOozd5myfj7p0muD1mRVJvbUWbOzD+q3No2bWbaKy+DJ8DA==
   /@babel/plugin-proposal-object-rest-spread/7.11.0_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -622,15 +624,17 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-wzch41N4yztwoRw0ak+37wxwJM2oiIiy6huGCoqkvSTA9acYWcPfn9Y4aJqmFFJ70KTJUu29f3DQ43uJ9HXzEA==
-  /@babel/plugin-proposal-optional-catch-binding/7.10.4:
+  /@babel/plugin-proposal-object-rest-spread/7.11.0_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.11.6
+      '@babel/plugin-transform-parameters': 7.10.5_@babel+core@7.11.6
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-LflT6nPh+GK2MnFiKDyLiqSqVHkQnVf7hdoAvyTnnKj9xB3docGRsdPuxp6qqqW19ifK3xgc9U5/FwrSaCNX5g==
+      integrity: sha512-wzch41N4yztwoRw0ak+37wxwJM2oiIiy6huGCoqkvSTA9acYWcPfn9Y4aJqmFFJ70KTJUu29f3DQ43uJ9HXzEA==
   /@babel/plugin-proposal-optional-catch-binding/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -641,16 +645,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-LflT6nPh+GK2MnFiKDyLiqSqVHkQnVf7hdoAvyTnnKj9xB3docGRsdPuxp6qqqW19ifK3xgc9U5/FwrSaCNX5g==
-  /@babel/plugin-proposal-optional-chaining/7.11.0:
+  /@babel/plugin-proposal-optional-catch-binding/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/helper-skip-transparent-expression-wrappers': 7.11.0
-      '@babel/plugin-syntax-optional-chaining': 7.8.3
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.11.6
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-v9fZIu3Y8562RRwhm1BbMRxtqZNFmFA2EG+pT2diuU8PT3H6T/KXoZ54KgYisfOFZHV6PfvAiBIZ9Rcz+/JCxA==
+      integrity: sha512-LflT6nPh+GK2MnFiKDyLiqSqVHkQnVf7hdoAvyTnnKj9xB3docGRsdPuxp6qqqW19ifK3xgc9U5/FwrSaCNX5g==
   /@babel/plugin-proposal-optional-chaining/7.11.0_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -662,15 +666,17 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-v9fZIu3Y8562RRwhm1BbMRxtqZNFmFA2EG+pT2diuU8PT3H6T/KXoZ54KgYisfOFZHV6PfvAiBIZ9Rcz+/JCxA==
-  /@babel/plugin-proposal-private-methods/7.10.4:
+  /@babel/plugin-proposal-optional-chaining/7.11.0_@babel+core@7.11.6:
     dependencies:
-      '@babel/helper-create-class-features-plugin': 7.10.5
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-skip-transparent-expression-wrappers': 7.11.0
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.11.6
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-wh5GJleuI8k3emgTg5KkJK6kHNsGEr0uBTDBuQUBJwckk9xs1ez79ioheEVVxMLyPscB0LfkbVHslQqIzWV6Bw==
+      integrity: sha512-v9fZIu3Y8562RRwhm1BbMRxtqZNFmFA2EG+pT2diuU8PT3H6T/KXoZ54KgYisfOFZHV6PfvAiBIZ9Rcz+/JCxA==
   /@babel/plugin-proposal-private-methods/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -681,17 +687,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-wh5GJleuI8k3emgTg5KkJK6kHNsGEr0uBTDBuQUBJwckk9xs1ez79ioheEVVxMLyPscB0LfkbVHslQqIzWV6Bw==
-  /@babel/plugin-proposal-unicode-property-regex/7.10.4:
+  /@babel/plugin-proposal-private-methods/7.10.4_@babel+core@7.11.6:
     dependencies:
-      '@babel/helper-create-regexp-features-plugin': 7.10.4
+      '@babel/core': 7.11.6
+      '@babel/helper-create-class-features-plugin': 7.10.5_@babel+core@7.11.6
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
-    engines:
-      node: '>=4'
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-H+3fOgPnEXFL9zGYtKQe4IDOPKYlZdF1kqFDQRRb8PK4B8af1vAGK04tF5iQAAsui+mHNBQSAtd2/ndEDe9wuA==
+      integrity: sha512-wh5GJleuI8k3emgTg5KkJK6kHNsGEr0uBTDBuQUBJwckk9xs1ez79ioheEVVxMLyPscB0LfkbVHslQqIzWV6Bw==
   /@babel/plugin-proposal-unicode-property-regex/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -704,14 +709,18 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-H+3fOgPnEXFL9zGYtKQe4IDOPKYlZdF1kqFDQRRb8PK4B8af1vAGK04tF5iQAAsui+mHNBQSAtd2/ndEDe9wuA==
-  /@babel/plugin-syntax-async-generators/7.8.4:
+  /@babel/plugin-proposal-unicode-property-regex/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
+      '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.11.6
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
+    engines:
+      node: '>=4'
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
+      integrity: sha512-H+3fOgPnEXFL9zGYtKQe4IDOPKYlZdF1kqFDQRRb8PK4B8af1vAGK04tF5iQAAsui+mHNBQSAtd2/ndEDe9wuA==
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -721,14 +730,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
-  /@babel/plugin-syntax-class-properties/7.10.4:
+  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==
+      integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
   /@babel/plugin-syntax-class-properties/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -738,14 +748,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==
-  /@babel/plugin-syntax-dynamic-import/7.8.3:
+  /@babel/plugin-syntax-class-properties/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
+      integrity: sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==
   /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -755,14 +766,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
-  /@babel/plugin-syntax-export-namespace-from/7.8.3:
+  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==
+      integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
   /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -772,14 +784,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==
-  /@babel/plugin-syntax-flow/7.10.4:
+  /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-yxQsX1dJixF4qEEdzVbst3SZQ58Nrooz8NV9Z9GL4byTE25BvJgl5lf0RECUf0fh28rZBb/RYTWn/eeKwCMrZQ==
+      integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==
   /@babel/plugin-syntax-flow/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -789,14 +802,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-yxQsX1dJixF4qEEdzVbst3SZQ58Nrooz8NV9Z9GL4byTE25BvJgl5lf0RECUf0fh28rZBb/RYTWn/eeKwCMrZQ==
-  /@babel/plugin-syntax-json-strings/7.8.3:
+  /@babel/plugin-syntax-flow/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
+      integrity: sha512-yxQsX1dJixF4qEEdzVbst3SZQ58Nrooz8NV9Z9GL4byTE25BvJgl5lf0RECUf0fh28rZBb/RYTWn/eeKwCMrZQ==
   /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -806,14 +820,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
-  /@babel/plugin-syntax-jsx/7.10.4:
+  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==
+      integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
   /@babel/plugin-syntax-jsx/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -823,14 +838,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==
-  /@babel/plugin-syntax-logical-assignment-operators/7.10.4:
+  /@babel/plugin-syntax-jsx/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==
+      integrity: sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==
   /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -840,14 +856,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==
-  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3:
+  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
+      integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -857,14 +874,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
-  /@babel/plugin-syntax-numeric-separator/7.10.4:
+  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==
+      integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
   /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -874,14 +892,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==
-  /@babel/plugin-syntax-object-rest-spread/7.8.3:
+  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
+      integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -891,14 +910,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
-  /@babel/plugin-syntax-optional-catch-binding/7.8.3:
+  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
+      integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
   /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -908,14 +928,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
-  /@babel/plugin-syntax-optional-chaining/7.8.3:
+  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
+      integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -925,14 +946,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
-  /@babel/plugin-syntax-top-level-await/7.10.4:
+  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-ni1brg4lXEmWyafKr0ccFWkJG0CeMt4WV1oyeBW6EFObF4oOHclbkj5cARxAPQyAQ2UTuplJyK4nfkXIMMFvsQ==
+      integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
   /@babel/plugin-syntax-top-level-await/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -942,14 +964,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-ni1brg4lXEmWyafKr0ccFWkJG0CeMt4WV1oyeBW6EFObF4oOHclbkj5cARxAPQyAQ2UTuplJyK4nfkXIMMFvsQ==
-  /@babel/plugin-transform-arrow-functions/7.10.4:
+  /@babel/plugin-syntax-top-level-await/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-9J/oD1jV0ZCBcgnoFWFq1vJd4msoKb/TCpGNFyyLt0zABdcvgK3aYikZ8HjzB14c26bc7E3Q1yugpwGy2aTPNA==
+      integrity: sha512-ni1brg4lXEmWyafKr0ccFWkJG0CeMt4WV1oyeBW6EFObF4oOHclbkj5cARxAPQyAQ2UTuplJyK4nfkXIMMFvsQ==
   /@babel/plugin-transform-arrow-functions/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -959,16 +982,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-9J/oD1jV0ZCBcgnoFWFq1vJd4msoKb/TCpGNFyyLt0zABdcvgK3aYikZ8HjzB14c26bc7E3Q1yugpwGy2aTPNA==
-  /@babel/plugin-transform-async-to-generator/7.10.4:
+  /@babel/plugin-transform-arrow-functions/7.10.4_@babel+core@7.11.6:
     dependencies:
-      '@babel/helper-module-imports': 7.10.4
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/helper-remap-async-to-generator': 7.11.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-F6nREOan7J5UXTLsDsZG3DXmZSVofr2tGNwfdrVwkDWHfQckbQXnXSPfD7iO+c/2HGqycwyLST3DnZ16n+cBJQ==
+      integrity: sha512-9J/oD1jV0ZCBcgnoFWFq1vJd4msoKb/TCpGNFyyLt0zABdcvgK3aYikZ8HjzB14c26bc7E3Q1yugpwGy2aTPNA==
   /@babel/plugin-transform-async-to-generator/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -980,14 +1002,17 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-F6nREOan7J5UXTLsDsZG3DXmZSVofr2tGNwfdrVwkDWHfQckbQXnXSPfD7iO+c/2HGqycwyLST3DnZ16n+cBJQ==
-  /@babel/plugin-transform-block-scoped-functions/7.10.4:
+  /@babel/plugin-transform-async-to-generator/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
+      '@babel/helper-module-imports': 7.10.4
       '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-remap-async-to-generator': 7.11.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-WzXDarQXYYfjaV1szJvN3AD7rZgZzC1JtjJZ8dMHUyiK8mxPRahynp14zzNjU3VkPqPsO38CzxiWO1c9ARZ8JA==
+      integrity: sha512-F6nREOan7J5UXTLsDsZG3DXmZSVofr2tGNwfdrVwkDWHfQckbQXnXSPfD7iO+c/2HGqycwyLST3DnZ16n+cBJQ==
   /@babel/plugin-transform-block-scoped-functions/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -997,14 +1022,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-WzXDarQXYYfjaV1szJvN3AD7rZgZzC1JtjJZ8dMHUyiK8mxPRahynp14zzNjU3VkPqPsO38CzxiWO1c9ARZ8JA==
-  /@babel/plugin-transform-block-scoping/7.11.1:
+  /@babel/plugin-transform-block-scoped-functions/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-00dYeDE0EVEHuuM+26+0w/SCL0BH2Qy7LwHuI4Hi4MH5gkC8/AqMN5uWFJIsoXZrAphiMm1iXzBw6L2T+eA0ew==
+      integrity: sha512-WzXDarQXYYfjaV1szJvN3AD7rZgZzC1JtjJZ8dMHUyiK8mxPRahynp14zzNjU3VkPqPsO38CzxiWO1c9ARZ8JA==
   /@babel/plugin-transform-block-scoping/7.11.1_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1014,21 +1040,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-00dYeDE0EVEHuuM+26+0w/SCL0BH2Qy7LwHuI4Hi4MH5gkC8/AqMN5uWFJIsoXZrAphiMm1iXzBw6L2T+eA0ew==
-  /@babel/plugin-transform-classes/7.10.4:
+  /@babel/plugin-transform-block-scoping/7.11.1_@babel+core@7.11.6:
     dependencies:
-      '@babel/helper-annotate-as-pure': 7.10.4
-      '@babel/helper-define-map': 7.10.5
-      '@babel/helper-function-name': 7.10.4
-      '@babel/helper-optimise-call-expression': 7.10.4
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/helper-replace-supers': 7.10.4
-      '@babel/helper-split-export-declaration': 7.11.0
-      globals: 11.12.0
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-2oZ9qLjt161dn1ZE0Ms66xBncQH4In8Sqw1YWgBUZuGVJJS5c0OFZXL6dP2MRHrkU/eKhWg8CzFJhRQl50rQxA==
+      integrity: sha512-00dYeDE0EVEHuuM+26+0w/SCL0BH2Qy7LwHuI4Hi4MH5gkC8/AqMN5uWFJIsoXZrAphiMm1iXzBw6L2T+eA0ew==
   /@babel/plugin-transform-classes/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1045,14 +1065,22 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-2oZ9qLjt161dn1ZE0Ms66xBncQH4In8Sqw1YWgBUZuGVJJS5c0OFZXL6dP2MRHrkU/eKhWg8CzFJhRQl50rQxA==
-  /@babel/plugin-transform-computed-properties/7.10.4:
+  /@babel/plugin-transform-classes/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
+      '@babel/helper-annotate-as-pure': 7.10.4
+      '@babel/helper-define-map': 7.10.5
+      '@babel/helper-function-name': 7.10.4
+      '@babel/helper-optimise-call-expression': 7.10.4
       '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-replace-supers': 7.10.4
+      '@babel/helper-split-export-declaration': 7.11.0
+      globals: 11.12.0
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-JFwVDXcP/hM/TbyzGq3l/XWGut7p46Z3QvqFMXTfk6/09m7xZHJUN9xHfsv7vqqD4YnfI5ueYdSJtXqqBLyjBw==
+      integrity: sha512-2oZ9qLjt161dn1ZE0Ms66xBncQH4In8Sqw1YWgBUZuGVJJS5c0OFZXL6dP2MRHrkU/eKhWg8CzFJhRQl50rQxA==
   /@babel/plugin-transform-computed-properties/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1062,14 +1090,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-JFwVDXcP/hM/TbyzGq3l/XWGut7p46Z3QvqFMXTfk6/09m7xZHJUN9xHfsv7vqqD4YnfI5ueYdSJtXqqBLyjBw==
-  /@babel/plugin-transform-destructuring/7.10.4:
+  /@babel/plugin-transform-computed-properties/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==
+      integrity: sha512-JFwVDXcP/hM/TbyzGq3l/XWGut7p46Z3QvqFMXTfk6/09m7xZHJUN9xHfsv7vqqD4YnfI5ueYdSJtXqqBLyjBw==
   /@babel/plugin-transform-destructuring/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1079,15 +1108,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==
-  /@babel/plugin-transform-dotall-regex/7.10.4:
+  /@babel/plugin-transform-destructuring/7.10.4_@babel+core@7.11.6:
     dependencies:
-      '@babel/helper-create-regexp-features-plugin': 7.10.4
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-ZEAVvUTCMlMFAbASYSVQoxIbHm2OkG2MseW6bV2JjIygOjdVv8tuxrCTzj1+Rynh7ODb8GivUy7dzEXzEhuPaA==
+      integrity: sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==
   /@babel/plugin-transform-dotall-regex/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1098,14 +1127,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-ZEAVvUTCMlMFAbASYSVQoxIbHm2OkG2MseW6bV2JjIygOjdVv8tuxrCTzj1+Rynh7ODb8GivUy7dzEXzEhuPaA==
-  /@babel/plugin-transform-duplicate-keys/7.10.4:
+  /@babel/plugin-transform-dotall-regex/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
+      '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.11.6
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-GL0/fJnmgMclHiBTTWXNlYjYsA7rDrtsazHG6mglaGSTh0KsrW04qml+Bbz9FL0LcJIRwBWL5ZqlNHKTkU3xAA==
+      integrity: sha512-ZEAVvUTCMlMFAbASYSVQoxIbHm2OkG2MseW6bV2JjIygOjdVv8tuxrCTzj1+Rynh7ODb8GivUy7dzEXzEhuPaA==
   /@babel/plugin-transform-duplicate-keys/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1115,15 +1146,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-GL0/fJnmgMclHiBTTWXNlYjYsA7rDrtsazHG6mglaGSTh0KsrW04qml+Bbz9FL0LcJIRwBWL5ZqlNHKTkU3xAA==
-  /@babel/plugin-transform-exponentiation-operator/7.10.4:
+  /@babel/plugin-transform-duplicate-keys/7.10.4_@babel+core@7.11.6:
     dependencies:
-      '@babel/helper-builder-binary-assignment-operator-visitor': 7.10.4
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-S5HgLVgkBcRdyQAHbKj+7KyuWx8C6t5oETmUuwz1pt3WTWJhsUV0WIIXuVvfXMxl/QQyHKlSCNNtaIamG8fysw==
+      integrity: sha512-GL0/fJnmgMclHiBTTWXNlYjYsA7rDrtsazHG6mglaGSTh0KsrW04qml+Bbz9FL0LcJIRwBWL5ZqlNHKTkU3xAA==
   /@babel/plugin-transform-exponentiation-operator/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1134,16 +1165,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-S5HgLVgkBcRdyQAHbKj+7KyuWx8C6t5oETmUuwz1pt3WTWJhsUV0WIIXuVvfXMxl/QQyHKlSCNNtaIamG8fysw==
-  /@babel/plugin-transform-flow-comments/7.10.4:
+  /@babel/plugin-transform-exponentiation-operator/7.10.4_@babel+core@7.11.6:
     dependencies:
-      '@babel/generator': 7.11.4
+      '@babel/core': 7.11.6
+      '@babel/helper-builder-binary-assignment-operator-visitor': 7.10.4
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-flow': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-wiwS5fCzeWP71WLIzAoFAPTk0GLnhpUfGV4ygwX+Zib6nYiaLhUOWsjLt6+hCwCoH/bwZSg7Qzlc2AuzXg/mbg==
+      integrity: sha512-S5HgLVgkBcRdyQAHbKj+7KyuWx8C6t5oETmUuwz1pt3WTWJhsUV0WIIXuVvfXMxl/QQyHKlSCNNtaIamG8fysw==
   /@babel/plugin-transform-flow-comments/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1155,15 +1186,17 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-wiwS5fCzeWP71WLIzAoFAPTk0GLnhpUfGV4ygwX+Zib6nYiaLhUOWsjLt6+hCwCoH/bwZSg7Qzlc2AuzXg/mbg==
-  /@babel/plugin-transform-flow-strip-types/7.10.4:
+  /@babel/plugin-transform-flow-comments/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
+      '@babel/generator': 7.11.4
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-flow': 7.10.4
+      '@babel/plugin-syntax-flow': 7.10.4_@babel+core@7.11.6
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-XTadyuqNst88UWBTdLjM+wEY7BFnY2sYtPyAidfC7M/QaZnSuIZpMvLxqGT7phAcnGyWh/XQFLKcGf04CnvxSQ==
+      integrity: sha512-wiwS5fCzeWP71WLIzAoFAPTk0GLnhpUfGV4ygwX+Zib6nYiaLhUOWsjLt6+hCwCoH/bwZSg7Qzlc2AuzXg/mbg==
   /@babel/plugin-transform-flow-strip-types/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1174,14 +1207,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-XTadyuqNst88UWBTdLjM+wEY7BFnY2sYtPyAidfC7M/QaZnSuIZpMvLxqGT7phAcnGyWh/XQFLKcGf04CnvxSQ==
-  /@babel/plugin-transform-for-of/7.10.4:
+  /@babel/plugin-transform-flow-strip-types/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-flow': 7.10.4_@babel+core@7.11.6
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==
+      integrity: sha512-XTadyuqNst88UWBTdLjM+wEY7BFnY2sYtPyAidfC7M/QaZnSuIZpMvLxqGT7phAcnGyWh/XQFLKcGf04CnvxSQ==
   /@babel/plugin-transform-for-of/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1191,15 +1226,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==
-  /@babel/plugin-transform-function-name/7.10.4:
+  /@babel/plugin-transform-for-of/7.10.4_@babel+core@7.11.6:
     dependencies:
-      '@babel/helper-function-name': 7.10.4
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-OcDCq2y5+E0dVD5MagT5X+yTRbcvFjDI2ZVAottGH6tzqjx/LKpgkUepu3hp/u4tZBzxxpNGwLsAvGBvQ2mJzg==
+      integrity: sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==
   /@babel/plugin-transform-function-name/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1210,14 +1245,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-OcDCq2y5+E0dVD5MagT5X+yTRbcvFjDI2ZVAottGH6tzqjx/LKpgkUepu3hp/u4tZBzxxpNGwLsAvGBvQ2mJzg==
-  /@babel/plugin-transform-literals/7.10.4:
+  /@babel/plugin-transform-function-name/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
+      '@babel/helper-function-name': 7.10.4
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-Xd/dFSTEVuUWnyZiMu76/InZxLTYilOSr1UlHV+p115Z/Le2Fi1KXkJUYz0b42DfndostYlPub3m8ZTQlMaiqQ==
+      integrity: sha512-OcDCq2y5+E0dVD5MagT5X+yTRbcvFjDI2ZVAottGH6tzqjx/LKpgkUepu3hp/u4tZBzxxpNGwLsAvGBvQ2mJzg==
   /@babel/plugin-transform-literals/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1227,14 +1264,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Xd/dFSTEVuUWnyZiMu76/InZxLTYilOSr1UlHV+p115Z/Le2Fi1KXkJUYz0b42DfndostYlPub3m8ZTQlMaiqQ==
-  /@babel/plugin-transform-member-expression-literals/7.10.4:
+  /@babel/plugin-transform-literals/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-0bFOvPyAoTBhtcJLr9VcwZqKmSjFml1iVxvPL0ReomGU53CX53HsM4h2SzckNdkQcHox1bpAqzxBI1Y09LlBSw==
+      integrity: sha512-Xd/dFSTEVuUWnyZiMu76/InZxLTYilOSr1UlHV+p115Z/Le2Fi1KXkJUYz0b42DfndostYlPub3m8ZTQlMaiqQ==
   /@babel/plugin-transform-member-expression-literals/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1244,16 +1282,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-0bFOvPyAoTBhtcJLr9VcwZqKmSjFml1iVxvPL0ReomGU53CX53HsM4h2SzckNdkQcHox1bpAqzxBI1Y09LlBSw==
-  /@babel/plugin-transform-modules-amd/7.10.5:
+  /@babel/plugin-transform-member-expression-literals/7.10.4_@babel+core@7.11.6:
     dependencies:
-      '@babel/helper-module-transforms': 7.11.0
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
-      babel-plugin-dynamic-import-node: 2.3.3
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-elm5uruNio7CTLFItVC/rIzKLfQ17+fX7EVz5W0TMgIHFo1zY0Ozzx+lgwhL4plzl8OzVn6Qasx5DeEFyoNiRw==
+      integrity: sha512-0bFOvPyAoTBhtcJLr9VcwZqKmSjFml1iVxvPL0ReomGU53CX53HsM4h2SzckNdkQcHox1bpAqzxBI1Y09LlBSw==
   /@babel/plugin-transform-modules-amd/7.10.5_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1265,17 +1302,17 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-elm5uruNio7CTLFItVC/rIzKLfQ17+fX7EVz5W0TMgIHFo1zY0Ozzx+lgwhL4plzl8OzVn6Qasx5DeEFyoNiRw==
-  /@babel/plugin-transform-modules-commonjs/7.10.4:
+  /@babel/plugin-transform-modules-amd/7.10.5_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-module-transforms': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/helper-simple-access': 7.10.4
       babel-plugin-dynamic-import-node: 2.3.3
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-Xj7Uq5o80HDLlW64rVfDBhao6OX89HKUmb+9vWYaLXBZOma4gA6tw4Ni1O5qVDoZWUV0fxMYA0aYzOawz0l+1w==
+      integrity: sha512-elm5uruNio7CTLFItVC/rIzKLfQ17+fX7EVz5W0TMgIHFo1zY0Ozzx+lgwhL4plzl8OzVn6Qasx5DeEFyoNiRw==
   /@babel/plugin-transform-modules-commonjs/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1288,17 +1325,18 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Xj7Uq5o80HDLlW64rVfDBhao6OX89HKUmb+9vWYaLXBZOma4gA6tw4Ni1O5qVDoZWUV0fxMYA0aYzOawz0l+1w==
-  /@babel/plugin-transform-modules-systemjs/7.10.5:
+  /@babel/plugin-transform-modules-commonjs/7.10.4_@babel+core@7.11.6:
     dependencies:
-      '@babel/helper-hoist-variables': 7.10.4
+      '@babel/core': 7.11.6
       '@babel/helper-module-transforms': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-simple-access': 7.10.4
       babel-plugin-dynamic-import-node: 2.3.3
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-f4RLO/OL14/FP1AEbcsWMzpbUz6tssRaeQg11RH1BP/XnPpRoVwgeYViMFacnkaw4k4wjRSjn3ip1Uw9TaXuMw==
+      integrity: sha512-Xj7Uq5o80HDLlW64rVfDBhao6OX89HKUmb+9vWYaLXBZOma4gA6tw4Ni1O5qVDoZWUV0fxMYA0aYzOawz0l+1w==
   /@babel/plugin-transform-modules-systemjs/7.10.5_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1311,15 +1349,18 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-f4RLO/OL14/FP1AEbcsWMzpbUz6tssRaeQg11RH1BP/XnPpRoVwgeYViMFacnkaw4k4wjRSjn3ip1Uw9TaXuMw==
-  /@babel/plugin-transform-modules-umd/7.10.4:
+  /@babel/plugin-transform-modules-systemjs/7.10.5_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
+      '@babel/helper-hoist-variables': 7.10.4
       '@babel/helper-module-transforms': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
+      babel-plugin-dynamic-import-node: 2.3.3
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-mohW5q3uAEt8T45YT7Qc5ws6mWgJAaL/8BfWD9Dodo1A3RKWli8wTS+WiQ/knF+tXlPirW/1/MqzzGfCExKECA==
+      integrity: sha512-f4RLO/OL14/FP1AEbcsWMzpbUz6tssRaeQg11RH1BP/XnPpRoVwgeYViMFacnkaw4k4wjRSjn3ip1Uw9TaXuMw==
   /@babel/plugin-transform-modules-umd/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1330,14 +1371,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-mohW5q3uAEt8T45YT7Qc5ws6mWgJAaL/8BfWD9Dodo1A3RKWli8wTS+WiQ/knF+tXlPirW/1/MqzzGfCExKECA==
-  /@babel/plugin-transform-named-capturing-groups-regex/7.10.4:
+  /@babel/plugin-transform-modules-umd/7.10.4_@babel+core@7.11.6:
     dependencies:
-      '@babel/helper-create-regexp-features-plugin': 7.10.4
+      '@babel/core': 7.11.6
+      '@babel/helper-module-transforms': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-V6LuOnD31kTkxQPhKiVYzYC/Jgdq53irJC/xBSmqcNcqFGV+PER4l6rU5SH2Vl7bH9mLDHcc0+l9HUOe4RNGKA==
+      integrity: sha512-mohW5q3uAEt8T45YT7Qc5ws6mWgJAaL/8BfWD9Dodo1A3RKWli8wTS+WiQ/knF+tXlPirW/1/MqzzGfCExKECA==
   /@babel/plugin-transform-named-capturing-groups-regex/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1347,14 +1390,15 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-V6LuOnD31kTkxQPhKiVYzYC/Jgdq53irJC/xBSmqcNcqFGV+PER4l6rU5SH2Vl7bH9mLDHcc0+l9HUOe4RNGKA==
-  /@babel/plugin-transform-new-target/7.10.4:
+  /@babel/plugin-transform-named-capturing-groups-regex/7.10.4_@babel+core@7.11.6:
     dependencies:
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/core': 7.11.6
+      '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.11.6
     dev: false
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.0.0
     resolution:
-      integrity: sha512-YXwWUDAH/J6dlfwqlWsztI2Puz1NtUAubXhOPLQ5gjR/qmQ5U96DY4FQO8At33JN4XPBhrjB8I4eMmLROjjLjw==
+      integrity: sha512-V6LuOnD31kTkxQPhKiVYzYC/Jgdq53irJC/xBSmqcNcqFGV+PER4l6rU5SH2Vl7bH9mLDHcc0+l9HUOe4RNGKA==
   /@babel/plugin-transform-new-target/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1364,15 +1408,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-YXwWUDAH/J6dlfwqlWsztI2Puz1NtUAubXhOPLQ5gjR/qmQ5U96DY4FQO8At33JN4XPBhrjB8I4eMmLROjjLjw==
-  /@babel/plugin-transform-object-super/7.10.4:
+  /@babel/plugin-transform-new-target/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/helper-replace-supers': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-5iTw0JkdRdJvr7sY0vHqTpnruUpTea32JHmq/atIWqsnNussbRzjEDyWep8UNztt1B5IusBYg8Irb0bLbiEBCQ==
+      integrity: sha512-YXwWUDAH/J6dlfwqlWsztI2Puz1NtUAubXhOPLQ5gjR/qmQ5U96DY4FQO8At33JN4XPBhrjB8I4eMmLROjjLjw==
   /@babel/plugin-transform-object-super/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1383,15 +1427,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-5iTw0JkdRdJvr7sY0vHqTpnruUpTea32JHmq/atIWqsnNussbRzjEDyWep8UNztt1B5IusBYg8Irb0bLbiEBCQ==
-  /@babel/plugin-transform-parameters/7.10.5:
+  /@babel/plugin-transform-object-super/7.10.4_@babel+core@7.11.6:
     dependencies:
-      '@babel/helper-get-function-arity': 7.10.4
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-replace-supers': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-xPHwUj5RdFV8l1wuYiu5S9fqWGM2DrYc24TMvUiRrPVm+SM3XeqU9BcokQX/kEUe+p2RBwy+yoiR1w/Blq6ubw==
+      integrity: sha512-5iTw0JkdRdJvr7sY0vHqTpnruUpTea32JHmq/atIWqsnNussbRzjEDyWep8UNztt1B5IusBYg8Irb0bLbiEBCQ==
   /@babel/plugin-transform-parameters/7.10.5_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1402,14 +1447,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-xPHwUj5RdFV8l1wuYiu5S9fqWGM2DrYc24TMvUiRrPVm+SM3XeqU9BcokQX/kEUe+p2RBwy+yoiR1w/Blq6ubw==
-  /@babel/plugin-transform-property-literals/7.10.4:
+  /@babel/plugin-transform-parameters/7.10.5_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
+      '@babel/helper-get-function-arity': 7.10.4
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-ofsAcKiUxQ8TY4sScgsGeR2vJIsfrzqvFb9GvJ5UdXDzl+MyYCaBj/FGzXuv7qE0aJcjWMILny1epqelnFlz8g==
+      integrity: sha512-xPHwUj5RdFV8l1wuYiu5S9fqWGM2DrYc24TMvUiRrPVm+SM3XeqU9BcokQX/kEUe+p2RBwy+yoiR1w/Blq6ubw==
   /@babel/plugin-transform-property-literals/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1419,14 +1466,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-ofsAcKiUxQ8TY4sScgsGeR2vJIsfrzqvFb9GvJ5UdXDzl+MyYCaBj/FGzXuv7qE0aJcjWMILny1epqelnFlz8g==
-  /@babel/plugin-transform-react-display-name/7.10.4:
+  /@babel/plugin-transform-property-literals/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-Zd4X54Mu9SBfPGnEcaGcOrVAYOtjT2on8QZkLKEq1S/tHexG39d9XXGZv19VfRrDjPJzFmPfTAqOQS1pfFOujw==
+      integrity: sha512-ofsAcKiUxQ8TY4sScgsGeR2vJIsfrzqvFb9GvJ5UdXDzl+MyYCaBj/FGzXuv7qE0aJcjWMILny1epqelnFlz8g==
   /@babel/plugin-transform-react-display-name/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1436,16 +1484,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Zd4X54Mu9SBfPGnEcaGcOrVAYOtjT2on8QZkLKEq1S/tHexG39d9XXGZv19VfRrDjPJzFmPfTAqOQS1pfFOujw==
-  /@babel/plugin-transform-react-jsx-development/7.10.4:
+  /@babel/plugin-transform-react-display-name/7.10.4_@babel+core@7.11.6:
     dependencies:
-      '@babel/helper-builder-react-jsx-experimental': 7.10.5
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-jsx': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-RM3ZAd1sU1iQ7rI2dhrZRZGv0aqzNQMbkIUCS1txYpi9wHQ2ZHNjo5TwX+UD6pvFW4AbWqLVYvKy5qJSAyRGjQ==
+      integrity: sha512-Zd4X54Mu9SBfPGnEcaGcOrVAYOtjT2on8QZkLKEq1S/tHexG39d9XXGZv19VfRrDjPJzFmPfTAqOQS1pfFOujw==
   /@babel/plugin-transform-react-jsx-development/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1457,15 +1504,17 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-RM3ZAd1sU1iQ7rI2dhrZRZGv0aqzNQMbkIUCS1txYpi9wHQ2ZHNjo5TwX+UD6pvFW4AbWqLVYvKy5qJSAyRGjQ==
-  /@babel/plugin-transform-react-jsx-self/7.10.4:
+  /@babel/plugin-transform-react-jsx-development/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
+      '@babel/helper-builder-react-jsx-experimental': 7.10.5
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-jsx': 7.10.4
+      '@babel/plugin-syntax-jsx': 7.10.4_@babel+core@7.11.6
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-yOvxY2pDiVJi0axdTWHSMi5T0DILN+H+SaeJeACHKjQLezEzhLx9nEF9xgpBLPtkZsks9cnb5P9iBEi21En3gg==
+      integrity: sha512-RM3ZAd1sU1iQ7rI2dhrZRZGv0aqzNQMbkIUCS1txYpi9wHQ2ZHNjo5TwX+UD6pvFW4AbWqLVYvKy5qJSAyRGjQ==
   /@babel/plugin-transform-react-jsx-self/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1476,15 +1525,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-yOvxY2pDiVJi0axdTWHSMi5T0DILN+H+SaeJeACHKjQLezEzhLx9nEF9xgpBLPtkZsks9cnb5P9iBEi21En3gg==
-  /@babel/plugin-transform-react-jsx-source/7.10.5:
+  /@babel/plugin-transform-react-jsx-self/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-jsx': 7.10.4
+      '@babel/plugin-syntax-jsx': 7.10.4_@babel+core@7.11.6
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-wTeqHVkN1lfPLubRiZH3o73f4rfon42HpgxUSs86Nc+8QIcm/B9s8NNVXu/gwGcOyd7yDib9ikxoDLxJP0UiDA==
+      integrity: sha512-yOvxY2pDiVJi0axdTWHSMi5T0DILN+H+SaeJeACHKjQLezEzhLx9nEF9xgpBLPtkZsks9cnb5P9iBEi21En3gg==
   /@babel/plugin-transform-react-jsx-source/7.10.5_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1495,17 +1545,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-wTeqHVkN1lfPLubRiZH3o73f4rfon42HpgxUSs86Nc+8QIcm/B9s8NNVXu/gwGcOyd7yDib9ikxoDLxJP0UiDA==
-  /@babel/plugin-transform-react-jsx/7.10.4:
+  /@babel/plugin-transform-react-jsx-source/7.10.5_@babel+core@7.11.6:
     dependencies:
-      '@babel/helper-builder-react-jsx': 7.10.4
-      '@babel/helper-builder-react-jsx-experimental': 7.10.5
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-jsx': 7.10.4
+      '@babel/plugin-syntax-jsx': 7.10.4_@babel+core@7.11.6
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-L+MfRhWjX0eI7Js093MM6MacKU4M6dnCRa/QPDwYMxjljzSCzzlzKzj9Pk4P3OtrPcxr2N3znR419nr3Xw+65A==
+      integrity: sha512-wTeqHVkN1lfPLubRiZH3o73f4rfon42HpgxUSs86Nc+8QIcm/B9s8NNVXu/gwGcOyd7yDib9ikxoDLxJP0UiDA==
   /@babel/plugin-transform-react-jsx/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1518,15 +1567,18 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-L+MfRhWjX0eI7Js093MM6MacKU4M6dnCRa/QPDwYMxjljzSCzzlzKzj9Pk4P3OtrPcxr2N3znR419nr3Xw+65A==
-  /@babel/plugin-transform-react-pure-annotations/7.10.4:
+  /@babel/plugin-transform-react-jsx/7.10.4_@babel+core@7.11.6:
     dependencies:
-      '@babel/helper-annotate-as-pure': 7.10.4
+      '@babel/core': 7.11.6
+      '@babel/helper-builder-react-jsx': 7.10.4
+      '@babel/helper-builder-react-jsx-experimental': 7.10.5
       '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-jsx': 7.10.4_@babel+core@7.11.6
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-+njZkqcOuS8RaPakrnR9KvxjoG1ASJWpoIv/doyWngId88JoFlPlISenGXjrVacZUIALGUr6eodRs1vmPnF23A==
+      integrity: sha512-L+MfRhWjX0eI7Js093MM6MacKU4M6dnCRa/QPDwYMxjljzSCzzlzKzj9Pk4P3OtrPcxr2N3znR419nr3Xw+65A==
   /@babel/plugin-transform-react-pure-annotations/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1537,14 +1589,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-+njZkqcOuS8RaPakrnR9KvxjoG1ASJWpoIv/doyWngId88JoFlPlISenGXjrVacZUIALGUr6eodRs1vmPnF23A==
-  /@babel/plugin-transform-regenerator/7.10.4:
+  /@babel/plugin-transform-react-pure-annotations/7.10.4_@babel+core@7.11.6:
     dependencies:
-      regenerator-transform: 0.14.5
+      '@babel/core': 7.11.6
+      '@babel/helper-annotate-as-pure': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-3thAHwtor39A7C04XucbMg17RcZ3Qppfxr22wYzZNcVIkPHfpM9J0SO8zuCV6SZa265kxBJSrfKTvDCYqBFXGw==
+      integrity: sha512-+njZkqcOuS8RaPakrnR9KvxjoG1ASJWpoIv/doyWngId88JoFlPlISenGXjrVacZUIALGUr6eodRs1vmPnF23A==
   /@babel/plugin-transform-regenerator/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1554,14 +1608,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-3thAHwtor39A7C04XucbMg17RcZ3Qppfxr22wYzZNcVIkPHfpM9J0SO8zuCV6SZa265kxBJSrfKTvDCYqBFXGw==
-  /@babel/plugin-transform-reserved-words/7.10.4:
+  /@babel/plugin-transform-regenerator/7.10.4_@babel+core@7.11.6:
     dependencies:
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/core': 7.11.6
+      regenerator-transform: 0.14.5
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-hGsw1O6Rew1fkFbDImZIEqA8GoidwTAilwCyWqLBM9f+e/u/sQMQu7uX6dyokfOayRuuVfKOW4O7HvaBWM+JlQ==
+      integrity: sha512-3thAHwtor39A7C04XucbMg17RcZ3Qppfxr22wYzZNcVIkPHfpM9J0SO8zuCV6SZa265kxBJSrfKTvDCYqBFXGw==
   /@babel/plugin-transform-reserved-words/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1571,14 +1626,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-hGsw1O6Rew1fkFbDImZIEqA8GoidwTAilwCyWqLBM9f+e/u/sQMQu7uX6dyokfOayRuuVfKOW4O7HvaBWM+JlQ==
-  /@babel/plugin-transform-shorthand-properties/7.10.4:
+  /@babel/plugin-transform-reserved-words/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-AC2K/t7o07KeTIxMoHneyX90v3zkm5cjHJEokrPEAGEy3UCp8sLKfnfOIGdZ194fyN4wfX/zZUWT9trJZ0qc+Q==
+      integrity: sha512-hGsw1O6Rew1fkFbDImZIEqA8GoidwTAilwCyWqLBM9f+e/u/sQMQu7uX6dyokfOayRuuVfKOW4O7HvaBWM+JlQ==
   /@babel/plugin-transform-shorthand-properties/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1588,15 +1644,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-AC2K/t7o07KeTIxMoHneyX90v3zkm5cjHJEokrPEAGEy3UCp8sLKfnfOIGdZ194fyN4wfX/zZUWT9trJZ0qc+Q==
-  /@babel/plugin-transform-spread/7.11.0:
+  /@babel/plugin-transform-shorthand-properties/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/helper-skip-transparent-expression-wrappers': 7.11.0
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-UwQYGOqIdQJe4aWNyS7noqAnN2VbaczPLiEtln+zPowRNlD+79w3oi2TWfYe0eZgd+gjZCbsydN7lzWysDt+gw==
+      integrity: sha512-AC2K/t7o07KeTIxMoHneyX90v3zkm5cjHJEokrPEAGEy3UCp8sLKfnfOIGdZ194fyN4wfX/zZUWT9trJZ0qc+Q==
   /@babel/plugin-transform-spread/7.11.0_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1607,15 +1663,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-UwQYGOqIdQJe4aWNyS7noqAnN2VbaczPLiEtln+zPowRNlD+79w3oi2TWfYe0eZgd+gjZCbsydN7lzWysDt+gw==
-  /@babel/plugin-transform-sticky-regex/7.10.4:
+  /@babel/plugin-transform-spread/7.11.0_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/helper-regex': 7.10.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.11.0
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-Ddy3QZfIbEV0VYcVtFDCjeE4xwVTJWTmUtorAJkn6u/92Z/nWJNV+mILyqHKrUxXYKA2EoCilgoPePymKL4DvQ==
+      integrity: sha512-UwQYGOqIdQJe4aWNyS7noqAnN2VbaczPLiEtln+zPowRNlD+79w3oi2TWfYe0eZgd+gjZCbsydN7lzWysDt+gw==
   /@babel/plugin-transform-sticky-regex/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1626,15 +1683,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Ddy3QZfIbEV0VYcVtFDCjeE4xwVTJWTmUtorAJkn6u/92Z/nWJNV+mILyqHKrUxXYKA2EoCilgoPePymKL4DvQ==
-  /@babel/plugin-transform-template-literals/7.10.5:
+  /@babel/plugin-transform-sticky-regex/7.10.4_@babel+core@7.11.6:
     dependencies:
-      '@babel/helper-annotate-as-pure': 7.10.4
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-regex': 7.10.5
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-V/lnPGIb+KT12OQikDvgSuesRX14ck5FfJXt6+tXhdkJ+Vsd0lDCVtF6jcB4rNClYFzaB2jusZ+lNISDk2mMMw==
+      integrity: sha512-Ddy3QZfIbEV0VYcVtFDCjeE4xwVTJWTmUtorAJkn6u/92Z/nWJNV+mILyqHKrUxXYKA2EoCilgoPePymKL4DvQ==
   /@babel/plugin-transform-template-literals/7.10.5_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1645,14 +1703,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-V/lnPGIb+KT12OQikDvgSuesRX14ck5FfJXt6+tXhdkJ+Vsd0lDCVtF6jcB4rNClYFzaB2jusZ+lNISDk2mMMw==
-  /@babel/plugin-transform-typeof-symbol/7.10.4:
+  /@babel/plugin-transform-template-literals/7.10.5_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
+      '@babel/helper-annotate-as-pure': 7.10.4
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-QqNgYwuuW0y0H+kUE/GWSR45t/ccRhe14Fs/4ZRouNNQsyd4o3PG4OtHiIrepbM2WKUBDAXKCAK/Lk4VhzTaGA==
+      integrity: sha512-V/lnPGIb+KT12OQikDvgSuesRX14ck5FfJXt6+tXhdkJ+Vsd0lDCVtF6jcB4rNClYFzaB2jusZ+lNISDk2mMMw==
   /@babel/plugin-transform-typeof-symbol/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1662,14 +1722,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-QqNgYwuuW0y0H+kUE/GWSR45t/ccRhe14Fs/4ZRouNNQsyd4o3PG4OtHiIrepbM2WKUBDAXKCAK/Lk4VhzTaGA==
-  /@babel/plugin-transform-unicode-escapes/7.10.4:
+  /@babel/plugin-transform-typeof-symbol/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-y5XJ9waMti2J+e7ij20e+aH+fho7Wb7W8rNuu72aKRwCHFqQdhkdU2lo3uZ9tQuboEJcUFayXdARhcxLQ3+6Fg==
+      integrity: sha512-QqNgYwuuW0y0H+kUE/GWSR45t/ccRhe14Fs/4ZRouNNQsyd4o3PG4OtHiIrepbM2WKUBDAXKCAK/Lk4VhzTaGA==
   /@babel/plugin-transform-unicode-escapes/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1679,15 +1740,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-y5XJ9waMti2J+e7ij20e+aH+fho7Wb7W8rNuu72aKRwCHFqQdhkdU2lo3uZ9tQuboEJcUFayXdARhcxLQ3+6Fg==
-  /@babel/plugin-transform-unicode-regex/7.10.4:
+  /@babel/plugin-transform-unicode-escapes/7.10.4_@babel+core@7.11.6:
     dependencies:
-      '@babel/helper-create-regexp-features-plugin': 7.10.4
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-wNfsc4s8N2qnIwpO/WP2ZiSyjfpTamT2C9V9FDH/Ljub9zw6P3SjkXcFmc0RQUt96k2fmIvtla2MMjgTwIAC+A==
+      integrity: sha512-y5XJ9waMti2J+e7ij20e+aH+fho7Wb7W8rNuu72aKRwCHFqQdhkdU2lo3uZ9tQuboEJcUFayXdARhcxLQ3+6Fg==
   /@babel/plugin-transform-unicode-regex/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1698,81 +1759,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-wNfsc4s8N2qnIwpO/WP2ZiSyjfpTamT2C9V9FDH/Ljub9zw6P3SjkXcFmc0RQUt96k2fmIvtla2MMjgTwIAC+A==
-  /@babel/preset-env/7.11.0:
+  /@babel/plugin-transform-unicode-regex/7.10.4_@babel+core@7.11.6:
     dependencies:
-      '@babel/compat-data': 7.11.0
-      '@babel/helper-compilation-targets': 7.10.4
-      '@babel/helper-module-imports': 7.10.4
+      '@babel/core': 7.11.6
+      '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.11.6
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-proposal-async-generator-functions': 7.10.5
-      '@babel/plugin-proposal-class-properties': 7.10.4
-      '@babel/plugin-proposal-dynamic-import': 7.10.4
-      '@babel/plugin-proposal-export-namespace-from': 7.10.4
-      '@babel/plugin-proposal-json-strings': 7.10.4
-      '@babel/plugin-proposal-logical-assignment-operators': 7.11.0
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.10.4
-      '@babel/plugin-proposal-numeric-separator': 7.10.4
-      '@babel/plugin-proposal-object-rest-spread': 7.11.0
-      '@babel/plugin-proposal-optional-catch-binding': 7.10.4
-      '@babel/plugin-proposal-optional-chaining': 7.11.0
-      '@babel/plugin-proposal-private-methods': 7.10.4
-      '@babel/plugin-proposal-unicode-property-regex': 7.10.4
-      '@babel/plugin-syntax-async-generators': 7.8.4
-      '@babel/plugin-syntax-class-properties': 7.10.4
-      '@babel/plugin-syntax-dynamic-import': 7.8.3
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3
-      '@babel/plugin-syntax-json-strings': 7.8.3
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3
-      '@babel/plugin-syntax-numeric-separator': 7.10.4
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3
-      '@babel/plugin-syntax-optional-chaining': 7.8.3
-      '@babel/plugin-syntax-top-level-await': 7.10.4
-      '@babel/plugin-transform-arrow-functions': 7.10.4
-      '@babel/plugin-transform-async-to-generator': 7.10.4
-      '@babel/plugin-transform-block-scoped-functions': 7.10.4
-      '@babel/plugin-transform-block-scoping': 7.11.1
-      '@babel/plugin-transform-classes': 7.10.4
-      '@babel/plugin-transform-computed-properties': 7.10.4
-      '@babel/plugin-transform-destructuring': 7.10.4
-      '@babel/plugin-transform-dotall-regex': 7.10.4
-      '@babel/plugin-transform-duplicate-keys': 7.10.4
-      '@babel/plugin-transform-exponentiation-operator': 7.10.4
-      '@babel/plugin-transform-for-of': 7.10.4
-      '@babel/plugin-transform-function-name': 7.10.4
-      '@babel/plugin-transform-literals': 7.10.4
-      '@babel/plugin-transform-member-expression-literals': 7.10.4
-      '@babel/plugin-transform-modules-amd': 7.10.5
-      '@babel/plugin-transform-modules-commonjs': 7.10.4
-      '@babel/plugin-transform-modules-systemjs': 7.10.5
-      '@babel/plugin-transform-modules-umd': 7.10.4
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.10.4
-      '@babel/plugin-transform-new-target': 7.10.4
-      '@babel/plugin-transform-object-super': 7.10.4
-      '@babel/plugin-transform-parameters': 7.10.5
-      '@babel/plugin-transform-property-literals': 7.10.4
-      '@babel/plugin-transform-regenerator': 7.10.4
-      '@babel/plugin-transform-reserved-words': 7.10.4
-      '@babel/plugin-transform-shorthand-properties': 7.10.4
-      '@babel/plugin-transform-spread': 7.11.0
-      '@babel/plugin-transform-sticky-regex': 7.10.4
-      '@babel/plugin-transform-template-literals': 7.10.5
-      '@babel/plugin-transform-typeof-symbol': 7.10.4
-      '@babel/plugin-transform-unicode-escapes': 7.10.4
-      '@babel/plugin-transform-unicode-regex': 7.10.4
-      '@babel/preset-modules': 0.1.3
-      '@babel/types': 7.11.0
-      browserslist: 4.14.0
-      core-js-compat: 3.6.5
-      invariant: 2.2.4
-      levenary: 1.1.1
-      semver: 5.7.1
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-2u1/k7rG/gTh02dylX2kL3S0IJNF+J6bfDSp4DI2Ma8QN6Y9x9pmAax59fsCk6QUQG0yqH47yJWA+u1I1LccAg==
+      integrity: sha512-wNfsc4s8N2qnIwpO/WP2ZiSyjfpTamT2C9V9FDH/Ljub9zw6P3SjkXcFmc0RQUt96k2fmIvtla2MMjgTwIAC+A==
   /@babel/preset-env/7.11.0_@babel+core@7.11.4:
     dependencies:
       '@babel/compat-data': 7.11.0
@@ -1849,15 +1845,82 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-2u1/k7rG/gTh02dylX2kL3S0IJNF+J6bfDSp4DI2Ma8QN6Y9x9pmAax59fsCk6QUQG0yqH47yJWA+u1I1LccAg==
-  /@babel/preset-flow/7.10.4:
+  /@babel/preset-env/7.11.0_@babel+core@7.11.6:
     dependencies:
+      '@babel/compat-data': 7.11.0
+      '@babel/core': 7.11.6
+      '@babel/helper-compilation-targets': 7.10.4_@babel+core@7.11.6
+      '@babel/helper-module-imports': 7.10.4
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-transform-flow-strip-types': 7.10.4
+      '@babel/plugin-proposal-async-generator-functions': 7.10.5_@babel+core@7.11.6
+      '@babel/plugin-proposal-class-properties': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-proposal-dynamic-import': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-proposal-export-namespace-from': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-proposal-json-strings': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-proposal-logical-assignment-operators': 7.11.0_@babel+core@7.11.6
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-proposal-numeric-separator': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-proposal-object-rest-spread': 7.11.0_@babel+core@7.11.6
+      '@babel/plugin-proposal-optional-catch-binding': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-proposal-optional-chaining': 7.11.0_@babel+core@7.11.6
+      '@babel/plugin-proposal-private-methods': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-proposal-unicode-property-regex': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.11.6
+      '@babel/plugin-syntax-class-properties': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.11.6
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.11.6
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.11.6
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.11.6
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.11.6
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.11.6
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.11.6
+      '@babel/plugin-syntax-top-level-await': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-arrow-functions': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-async-to-generator': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-block-scoped-functions': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-block-scoping': 7.11.1_@babel+core@7.11.6
+      '@babel/plugin-transform-classes': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-computed-properties': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-destructuring': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-dotall-regex': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-duplicate-keys': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-exponentiation-operator': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-for-of': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-function-name': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-literals': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-member-expression-literals': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-modules-amd': 7.10.5_@babel+core@7.11.6
+      '@babel/plugin-transform-modules-commonjs': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-modules-systemjs': 7.10.5_@babel+core@7.11.6
+      '@babel/plugin-transform-modules-umd': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-new-target': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-object-super': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-parameters': 7.10.5_@babel+core@7.11.6
+      '@babel/plugin-transform-property-literals': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-regenerator': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-reserved-words': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-shorthand-properties': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-spread': 7.11.0_@babel+core@7.11.6
+      '@babel/plugin-transform-sticky-regex': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-template-literals': 7.10.5_@babel+core@7.11.6
+      '@babel/plugin-transform-typeof-symbol': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-unicode-escapes': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-unicode-regex': 7.10.4_@babel+core@7.11.6
+      '@babel/preset-modules': 0.1.3_@babel+core@7.11.6
+      '@babel/types': 7.11.0
+      browserslist: 4.14.0
+      core-js-compat: 3.6.5
+      invariant: 2.2.4
+      levenary: 1.1.1
+      semver: 5.7.1
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-XI6l1CptQCOBv+ZKYwynyswhtOKwpZZp5n0LG1QKCo8erRhqjoQV6nvx61Eg30JHpysWQSBwA2AWRU3pBbSY5g==
+      integrity: sha512-2u1/k7rG/gTh02dylX2kL3S0IJNF+J6bfDSp4DI2Ma8QN6Y9x9pmAax59fsCk6QUQG0yqH47yJWA+u1I1LccAg==
   /@babel/preset-flow/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1868,18 +1931,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-XI6l1CptQCOBv+ZKYwynyswhtOKwpZZp5n0LG1QKCo8erRhqjoQV6nvx61Eg30JHpysWQSBwA2AWRU3pBbSY5g==
-  /@babel/preset-modules/0.1.3:
+  /@babel/preset-flow/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-proposal-unicode-property-regex': 7.10.4
-      '@babel/plugin-transform-dotall-regex': 7.10.4
-      '@babel/types': 7.9.5
-      esutils: 2.0.3
+      '@babel/plugin-transform-flow-strip-types': 7.10.4_@babel+core@7.11.6
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==
+      integrity: sha512-XI6l1CptQCOBv+ZKYwynyswhtOKwpZZp5n0LG1QKCo8erRhqjoQV6nvx61Eg30JHpysWQSBwA2AWRU3pBbSY5g==
   /@babel/preset-modules/0.1.3_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1893,20 +1954,19 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==
-  /@babel/preset-react/7.10.4:
+  /@babel/preset-modules/0.1.3_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-transform-react-display-name': 7.10.4
-      '@babel/plugin-transform-react-jsx': 7.10.4
-      '@babel/plugin-transform-react-jsx-development': 7.10.4
-      '@babel/plugin-transform-react-jsx-self': 7.10.4
-      '@babel/plugin-transform-react-jsx-source': 7.10.5
-      '@babel/plugin-transform-react-pure-annotations': 7.10.4
+      '@babel/plugin-proposal-unicode-property-regex': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-dotall-regex': 7.10.4_@babel+core@7.11.6
+      '@babel/types': 7.9.5
+      esutils: 2.0.3
     dev: false
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-BrHp4TgOIy4M19JAfO1LhycVXOPWdDbTRep7eVyatf174Hff+6Uk53sDyajqZPu8W1qXRBiYOfIamek6jA7YVw==
+      integrity: sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==
   /@babel/preset-react/7.10.4_@babel+core@7.11.4:
     dependencies:
       '@babel/core': 7.11.4
@@ -1922,8 +1982,24 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-BrHp4TgOIy4M19JAfO1LhycVXOPWdDbTRep7eVyatf174Hff+6Uk53sDyajqZPu8W1qXRBiYOfIamek6jA7YVw==
-  /@babel/register/7.10.5:
+  /@babel/preset-react/7.10.4_@babel+core@7.11.6:
     dependencies:
+      '@babel/core': 7.11.6
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-transform-react-display-name': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-react-jsx': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-react-jsx-development': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-react-jsx-self': 7.10.4_@babel+core@7.11.6
+      '@babel/plugin-transform-react-jsx-source': 7.10.5_@babel+core@7.11.6
+      '@babel/plugin-transform-react-pure-annotations': 7.10.4_@babel+core@7.11.6
+    dev: false
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-BrHp4TgOIy4M19JAfO1LhycVXOPWdDbTRep7eVyatf174Hff+6Uk53sDyajqZPu8W1qXRBiYOfIamek6jA7YVw==
+  /@babel/register/7.10.5_@babel+core@7.11.4:
+    dependencies:
+      '@babel/core': 7.11.4
       find-cache-dir: 2.1.0
       lodash: 4.17.20
       make-dir: 2.1.0
@@ -1934,9 +2010,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-eYHdLv43nyvmPn9bfNfrcC4+iYNwdQ8Pxk1MFJuU/U5LpSYl/PH4dFMazCYZDFVi8ueG3shvO+AQfLrxpYulQw==
-  /@babel/register/7.10.5_@babel+core@7.11.4:
+  /@babel/register/7.10.5_@babel+core@7.11.6:
     dependencies:
-      '@babel/core': 7.11.4
+      '@babel/core': 7.11.6
       find-cache-dir: 2.1.0
       lodash: 4.17.20
       make-dir: 2.1.0
@@ -3065,9 +3141,9 @@ packages:
     dev: false
     resolution:
       integrity: sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=
-  /babel-loader/8.1.0_fbab4801791d746d265885e0d19f0bda:
+  /babel-loader/8.1.0_5a36cfe3630aa5e4fa0785cefae272b5:
     dependencies:
-      '@babel/core': 7.11.4
+      '@babel/core': 7.11.6
       find-cache-dir: 2.1.0
       loader-utils: 1.4.0
       mkdirp: 0.5.5
@@ -3082,8 +3158,9 @@ packages:
       webpack: '>=2'
     resolution:
       integrity: sha512-7q7nC1tYOrqvUrN3LQK4GwSk/TQorZSOlO9C+RZDZpODgyN4ZlCqE5q9cDsyWOliN+aU9B4JX01xK9eJXowJLw==
-  /babel-loader/8.1.0_webpack@4.44.1:
+  /babel-loader/8.1.0_fbab4801791d746d265885e0d19f0bda:
     dependencies:
+      '@babel/core': 7.11.4
       find-cache-dir: 2.1.0
       loader-utils: 1.4.0
       mkdirp: 0.5.5
@@ -5853,8 +5930,9 @@ packages:
       node: '>=4.x'
     resolution:
       integrity: sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
-  /gulp-babel/8.0.0:
+  /gulp-babel/8.0.0_@babel+core@7.11.4:
     dependencies:
+      '@babel/core': 7.11.4
       plugin-error: 1.0.1
       replace-ext: 1.0.1
       through2: 2.0.5
@@ -5866,9 +5944,9 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-oomaIqDXxFkg7lbpBou/gnUkX51/Y/M2ZfSjL2hdqXTAlSWZcgZtd2o0cOH0r/eE8LWD0+Q/PsLsr2DKOoqToQ==
-  /gulp-babel/8.0.0_@babel+core@7.11.4:
+  /gulp-babel/8.0.0_@babel+core@7.11.6:
     dependencies:
-      '@babel/core': 7.11.4
+      '@babel/core': 7.11.6
       plugin-error: 1.0.1
       replace-ext: 1.0.1
       through2: 2.0.5
@@ -7558,6 +7636,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==
+  /nanoid/3.1.16:
+    dev: false
+    engines:
+      node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1
+    hasBin: true
+    resolution:
+      integrity: sha512-+AK8MN0WHji40lj8AEuwLOvLSbWYApQpre/aFJZD71r43wVRLrOYS4FmJOPQYon1TqB462RzrrxlfA74XRES8w==
   /nanomatch/1.2.13:
     dependencies:
       arr-diff: 4.0.0
@@ -10804,7 +10889,7 @@ packages:
     dev: false
     name: '@rush-temp/cli'
     resolution:
-      integrity: sha512-jHwioCAMZd0G+tXEoMu0z0P32McdvLYbsgG7gZB/xlJK6WLW+CZkyF0o0o+YKXyAMS5Qn/wp6B/Y8Naw2kS/uQ==
+      integrity: sha512-D3IXIgj7msd6KeoVF+1IepNpHe8z4PtwmZcMW0ajkyBir+LsAB56BWmTOdO2yENpUlDg1EW/XNCzFKU33i4z/w==
       tarball: 'file:projects/cli.tgz'
     version: 0.0.0
   'file:projects/default-template.tgz':
@@ -10846,7 +10931,7 @@ packages:
     dev: false
     name: '@rush-temp/default-template'
     resolution:
-      integrity: sha512-vzKo7sU8hUtR4K5RpBobhO79GN+3WCW1yQEHtFZgv3NIQemJJMB/M0o/57UJUMfUmqL63R7ZrWev34z2DlrdbQ==
+      integrity: sha512-UcNH9nwu7iXunz85/ZuFaHavxRZT9s3DbFtSnBM8IIv+ZLxlt/3d9Myi9hVeM8Px2xN8Fqo9Qwxuv+9jDSH+PQ==
       tarball: 'file:projects/default-template.tgz'
     version: 0.0.0
   'file:projects/eslint-config.tgz':
@@ -10900,7 +10985,7 @@ packages:
     dev: false
     name: '@rush-temp/externalize'
     resolution:
-      integrity: sha512-hbmzOuN5H5YTFKWmuXc1jJMSOpWKGMu7CjWHwLX7v/dFgxnYgYxBR6zWcOiMjtzwhVu8K0loARI/O2YK9G4W2Q==
+      integrity: sha512-wBWFf5ZinzSYxut7Jn9HWRAXv6AR7TB1YWr2o3GxReN8Q176bnFU2vzGqWpjj/vQZ+atfjmc9e8NlPm6HXYbSg==
       tarball: 'file:projects/externalize.tgz'
     version: 0.0.0
   'file:projects/legacy-template.tgz':
@@ -10923,7 +11008,7 @@ packages:
     dev: false
     name: '@rush-temp/legacy-template'
     resolution:
-      integrity: sha512-nMPg+aujOZArJwNrswXTtRYVELOfym1544eBfEkXFMI8AM89Iv6Q0nJDxeehCqPZL2PaRMdgVwgh/bjqFlMCBA==
+      integrity: sha512-vKAMJAjwia0NsAniGY+7xhdTGoITp4bxKBASNcNk5qvYdKbqXFcqUot3tyQcENVgRKSDupw6hiOd3kJla8lEMg==
       tarball: 'file:projects/legacy-template.tgz'
     version: 0.0.0
   'file:projects/model.tgz':
@@ -10949,7 +11034,7 @@ packages:
     dev: false
     name: '@rush-temp/model'
     resolution:
-      integrity: sha512-G7zOZ+7d7TIdawHHeL+brkwPzSRrjWsDBr4Ez1hSJWdIAcvLgxx8bqtGHazTWsUEU4lugbMWmcbofUC3d8h/ag==
+      integrity: sha512-PAetJ85M8+Xq1oyGo/k1WHCpdHbxQQiFVvLG5jQzqlM9zb5TlS42UGAtG3M+/ZV0exHYOBFvY8E9v54alfMn/w==
       tarball: 'file:projects/model.tgz'
     version: 0.0.0
   'file:projects/parser.tgz':
@@ -10979,7 +11064,7 @@ packages:
     dev: false
     name: '@rush-temp/parser'
     resolution:
-      integrity: sha512-4z6Wxxc0TcAlPD+znCtASgIR5O6rqzpZXwI+g3szSa/J6pqcUFxHlwIa7P6DpvI59MFXCGwq44dScIn6x/VA1A==
+      integrity: sha512-XOhr4/MTi3KNddctatZD9cVC2dIc3PXV30rjOxuHXuofGzo+mGXtC5SvT6v6NWU+Ai0+QJxBMvtZGWKAPNVzvQ==
       tarball: 'file:projects/parser.tgz'
     version: 0.0.0
   'file:projects/plugin-markdown.tgz':
@@ -11028,11 +11113,12 @@ packages:
       lodash: 4.17.20
       missionlog: 1.6.0
       mocha: 7.2.0
+      nanoid: 3.1.16
       parse-github-url: 1.0.2
     dev: false
     name: '@rush-temp/template-library'
     resolution:
-      integrity: sha512-xk5YMX/uKFHPp8xG39D41XjSDJDlvpKMeEWDA5AI/QkcKPWvT+7IaUE3+NtgHBEdgaiIyd6dZLsncNlZmLiwpg==
+      integrity: sha512-51R3f7B+yIDVQ8Mk4SIkeTRhltThNF/QhzmE9lXBhL54d1JGvtNmCdeNyM/Uulw8LNkKpr+xtpEwQOZySx0WFA==
       tarball: 'file:projects/template-library.tgz'
     version: 0.0.0
   'file:projects/tests.tgz':
@@ -11054,6 +11140,7 @@ packages:
 registry: ''
 specifiers:
   '@babel/cli': ^7.8.4
+  '@babel/core': ^7.9.0
   '@babel/parser': ^7.9.4
   '@babel/plugin-proposal-class-properties': ^7.8.3
   '@babel/plugin-transform-flow-comments': ^7.8.3
@@ -11115,7 +11202,6 @@ specifiers:
   mini-css-extract-plugin: ^0.9.0
   missionlog: 1.6.0
   mocha: ^7.1.1
-  nanoid: ^3.1.3
   object.fromentries: ^2.0.2
   open-sans-fonts: ^1.6.2
   optimize-css-assets-webpack-plugin: ^5.0.3

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -27,6 +27,7 @@ dependencies:
   '@rush-temp/tests': 'file:projects/tests.tgz'
   '@rush-temp/types': 'file:projects/types.tgz'
   '@rushstack/eslint-patch': 1.0.3
+  array.prototype.flatmap: 1.2.3
   babel-eslint: 10.1.0_eslint@6.8.0
   babel-loader: 8.1.0_5a36cfe3630aa5e4fa0785cefae272b5
   bluebird: 3.7.2
@@ -10865,6 +10866,7 @@ packages:
       '@babel/preset-flow': 7.10.4_@babel+core@7.11.4
       '@babel/preset-react': 7.10.4_@babel+core@7.11.4
       '@babel/register': 7.10.5_@babel+core@7.11.4
+      array.prototype.flatmap: 1.2.3
       chai: 4.2.0
       del: 5.1.0
       eslint: 6.8.0
@@ -10889,7 +10891,7 @@ packages:
     dev: false
     name: '@rush-temp/cli'
     resolution:
-      integrity: sha512-D3IXIgj7msd6KeoVF+1IepNpHe8z4PtwmZcMW0ajkyBir+LsAB56BWmTOdO2yENpUlDg1EW/XNCzFKU33i4z/w==
+      integrity: sha512-ZlaBgQj6UjSagu6ImG9sm0ptt6OCQ1ZwgftYcZjSrL/Yue+L9d5u3LSaMRWynwjsggA7we0jsQPJOB+HXG5M5A==
       tarball: 'file:projects/cli.tgz'
     version: 0.0.0
   'file:projects/default-template.tgz':
@@ -11030,11 +11032,12 @@ packages:
       gulp-babel: 8.0.0_@babel+core@7.11.4
       gulp-util: 3.0.8
       mocha: 7.2.0
+      nanoid: 3.1.16
       taffydb: 2.7.3
     dev: false
     name: '@rush-temp/model'
     resolution:
-      integrity: sha512-PAetJ85M8+Xq1oyGo/k1WHCpdHbxQQiFVvLG5jQzqlM9zb5TlS42UGAtG3M+/ZV0exHYOBFvY8E9v54alfMn/w==
+      integrity: sha512-yEE/bVMbt/1chdAFIq+M+yAdJAolSfzEtPzwJewALCY/v45GFLqD7f4rbeKuL5KBXAq8VrN7/9YFvCoqscH/kw==
       tarball: 'file:projects/model.tgz'
     version: 0.0.0
   'file:projects/parser.tgz':
@@ -11167,6 +11170,7 @@ specifiers:
   '@rush-temp/tests': 'file:./projects/tests.tgz'
   '@rush-temp/types': 'file:./projects/types.tgz'
   '@rushstack/eslint-patch': ~1.0.2
+  array.prototype.flatmap: ~1.2.3
   babel-eslint: ^10.1.0
   babel-loader: ^8.1.0
   bluebird: ^3.7.2

--- a/packages/webdoc-cli/package.json
+++ b/packages/webdoc-cli/package.json
@@ -59,7 +59,8 @@
     "@babel/core": "^7.9.0",
     "gulp-util": "^3.0.8",
     "read-pkg-up": "~7.0.1",
-    "pkg-up": "~3.1.0"
+    "pkg-up": "~3.1.0",
+    "array.prototype.flatmap": "~1.2.3"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/packages/webdoc-cli/src/shims.js
+++ b/packages/webdoc-cli/src/shims.js
@@ -3,3 +3,7 @@
 if (!Object.fromEntries) {
   require("object.fromentries").shim();
 }
+
+if (!Array.prototype.flatMap) {
+  require("array.prototype.flatmap").shim();
+}

--- a/packages/webdoc-cli/src/sources/packages.js
+++ b/packages/webdoc-cli/src/sources/packages.js
@@ -4,6 +4,8 @@ import type {PackageDoc, SourceFile} from "@webdoc/types";
 import path from "path";
 import pkgUp from "pkg-up";
 
+let pkgId = 0;
+
 export function packages(sourceFiles: SourceFile[]): PackageDoc[] {
   const cache = new Map<string, PackageDoc>();
   const packages: PackageDoc[] = [];
@@ -25,6 +27,7 @@ export function packages(sourceFiles: SourceFile[]): PackageDoc[] {
 
         // Create PackageDoc for this package
         pkg = {
+          id: `package-${pkgId++}`,
           api: [],
           name: metadata.name,
           path: metadata.name,

--- a/packages/webdoc-default-template/helper/crawl/crawl-reference-explorer.js
+++ b/packages/webdoc-default-template/helper/crawl/crawl-reference-explorer.js
@@ -1,7 +1,7 @@
 // @flow
 
-const {SymbolLinks} = require("@webdoc/template-library");
 const {traverse} = require("@webdoc/model");
+const {linker} = require("../linker");
 
 /*::
 import type {
@@ -52,11 +52,7 @@ function crawlReference(doc /*: Doc */) {
 exports.crawlReference = crawlReference;
 
 function getPage(doc /*: Doc */) {
-  if (doc.type === "PackageDoc") {
-    return SymbolLinks.pathToUrl.get(doc.metadata.name);
-  }
-
-  return SymbolLinks.pathToUrl.get(doc.path);
+  return linker.getURI(doc);
 }
 
 /*::
@@ -169,7 +165,7 @@ function traversePackage(doc /*: Doc | PackageDoc */, context /*: Object */, par
 
 function buildExplorerTargetsTree(node /*: ExplorerNode */, parentTitle /*: string */ = "") /*: ExplorerTarget */ {
   const doc = node.doc;
-  const page = getPage(doc);
+  const page = doc.type !== "RootDoc" ? getPage(doc) : "index.html";
 
   let title = "";
 
@@ -199,7 +195,7 @@ function buildExplorerTargetsTree(node /*: ExplorerNode */, parentTitle /*: stri
 
       node.children.ClassIndex = {
         title: "Class Index",
-        page: SymbolLinks.getFileName("Class-Index"),
+        page: linker.createURI("Class-Index.html"),
       };
     }
 

--- a/packages/webdoc-default-template/helper/crawl/crawl.js
+++ b/packages/webdoc-default-template/helper/crawl/crawl.js
@@ -2,10 +2,10 @@
 
 const {crawlReference} = require("./crawl-reference-explorer");
 const {traverse} = require("@webdoc/model");
-const {SymbolLinks} = require("@webdoc/template-library");
+const {linker} = require("../linker");
 
 // This file crawls the document tree to:
-// + feed the SymbolLinks database with links to pages to be generated.
+// + feed the linker database with links to pages to be generated.
 // + build a hierarchy of explorer-targets
 
 /*::
@@ -33,22 +33,18 @@ function buildLinks(tree /*: RootDoc */) /*: void */ {
   traverse(tree, (doc) => {
     if (doc.type === "RootDoc") {
       doc.packages.forEach((packageDoc) => {
-        const link = SymbolLinks.createLink(packageDoc);
-
-        SymbolLinks.registerLink(packageDoc.metadata.name, link);
+        linker.getURI(packageDoc);
       });
 
       return;
     }
 
-    const link = SymbolLinks.createLink(doc);
-
-    SymbolLinks.registerLink(doc.path, link);
+    linker.getURI(doc);
   });
 }
 
 function buildIndex(tree /*: RootDoc */) /*: [id: string]: [] & { url: string } */ {
-  const classIndexUrl = SymbolLinks.getFileName("Class-Index");
+  const classIndexUrl = linker.createURI("Class-Index");
 
   const index /*: [id: string]: [] & { url: string } */ = {
     classes: [],

--- a/packages/webdoc-default-template/helper/explorer.js
+++ b/packages/webdoc-default-template/helper/explorer.js
@@ -1,9 +1,1 @@
 // @flow
-
-import {SymbolLinks} from "@webdoc/template-library";
-
-const explorerTargets = new Map();
-
-exports.createExplorerTarget = function createExplorerTarget(url) {
-
-};

--- a/packages/webdoc-default-template/helper/linker.js
+++ b/packages/webdoc-default-template/helper/linker.js
@@ -1,0 +1,4 @@
+const {LinkerPlugin} = require("@webdoc/template-library");
+const linker = new LinkerPlugin();
+
+exports.linker = linker;

--- a/packages/webdoc-default-template/helper/renderer-plugins/signature.js
+++ b/packages/webdoc-default-template/helper/renderer-plugins/signature.js
@@ -2,7 +2,7 @@
 import type {Doc} from "@webdoc/types";
 */
 
-const {SymbolLinks} = require("@webdoc/template-library");
+const {linker} = require("../linker");
 
 exports.signaturePlugin = {
   generateSignature(doc /*: Doc */) {
@@ -41,7 +41,7 @@ exports.signaturePlugin = {
             .map((param) =>
               param.identifier +
               (param.dataType ?
-                ": " + SymbolLinks.linkTo(param.dataType) :
+                ": " + linker.linkTo(param.dataType) :
                 ""
               ),
             )
@@ -52,25 +52,25 @@ exports.signaturePlugin = {
         signature += ` → {${
           (doc.returns || [])
             .map((returns) =>
-              (returns.dataType ? SymbolLinks.linkTo(returns.dataType) : ""))
+              (returns.dataType ? linker.linkTo(returns.dataType) : ""))
             .join(", ")
         }} `;
       }
       break;
     case "PropertyDoc":
       if (doc.dataType) {
-        signature += ": " + SymbolLinks.linkTo(doc.dataType);
+        signature += ": " + linker.linkTo(doc.dataType);
       }
       break;
     case "ClassDoc":
       if (doc.extends) {
         signature += ` extends ${
-          (doc.extends || []).map((superClass) => SymbolLinks.linkTo(superClass)).join(", ")
+          (doc.extends || []).map((superClass) => linker.linkTo(superClass)).join(", ")
         }`;
       }
       if (doc.implements) {
         signature += `\nimplements ${
-          (doc.implements || []).map((ifc) => SymbolLinks.linkTo(ifc)).join(", ")
+          (doc.implements || []).map((ifc) => linker.linkTo(ifc)).join(", ")
         }`;
       }
       break;

--- a/packages/webdoc-default-template/publish.js
+++ b/packages/webdoc-default-template/publish.js
@@ -50,7 +50,7 @@ let idToDoc/*: Map<string, Doc> */;
 exports.publish = (options /*: PublishOptions */) => {
   const docTree = options.documentTree;
   const outDir = path.normalize(options.config.opts.destination);
-  const index = linker.createURI("index.html");
+  const index = linker.createURI("index");
 
   fse.ensureDir(outDir);
 

--- a/packages/webdoc-default-template/publish.js
+++ b/packages/webdoc-default-template/publish.js
@@ -68,6 +68,11 @@ exports.publish = (options /*: PublishOptions */) => {
   idToDoc = new Map();
 
   traverse(docTree, (doc) => {
+    if (doc.type === "RootDoc") {
+      doc.packages.forEach((pkg) => {
+        idToDoc.set(pkg.id, pkg);
+      });
+    }
     idToDoc.set(doc.id, doc);
   });
 

--- a/packages/webdoc-model/package.json
+++ b/packages/webdoc-model/package.json
@@ -38,7 +38,8 @@
   "dependencies": {
     "@webdoc/types": "^1.0.1",
     "catharsis": "0.8.11",
-    "taffydb": "2.7.3"
+    "taffydb": "2.7.3",
+    "nanoid": "~3.1.16"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/packages/webdoc-model/src/doc.js
+++ b/packages/webdoc-model/src/doc.js
@@ -1,6 +1,7 @@
 // @flow
 
 import type {BaseDoc, ClassDoc, Doc, DocLink, DocType, ObjectDoc, TypedefDoc} from "@webdoc/types";
+import {nanoid} from "nanoid";
 
 const CANONICAL_SEPARATOR = /([.#~$])/;
 
@@ -30,6 +31,7 @@ function updateScope(doc: Doc, scopeStack: string[], scopePath: string): void {
  */
 export const createDoc = (name?: string, type?: string = "BaseDoc", options: any, instance: any) => {
   const doc = Object.assign(instance || {}, {
+    id: nanoid(),
     name,
     path: "",
     stack: [""],

--- a/packages/webdoc-model/src/query/query.js
+++ b/packages/webdoc-model/src/query/query.js
@@ -16,12 +16,12 @@ import {variant} from "./variant";
  */
 export function query(queryExpr: string | Query, docTree: Doc): Doc[] {
   queryExpr = typeof queryExpr === "string" ? parse(queryExpr) : queryExpr;
-  let results: Doc[] = [];
+  let results: Doc[] = [docTree];
 
   queryExpr.steps.forEach((stepExpr) => {
     results = results
       .flatMap((doc) => step(stepExpr, doc))
-      .filter((doc) => variant(doc));
+      .filter((doc) => variant(stepExpr.variant, doc));
   });
 
   return results;

--- a/packages/webdoc-model/src/query/step.js
+++ b/packages/webdoc-model/src/query/step.js
@@ -32,5 +32,5 @@ const stepHandlers = {
 };
 
 export function step(stepExpr: StepExpr, doc: Doc): Doc[] {
-  return stepHandlers[stepExpr.stepType](stepExpr.qualifier, doc);
+  return stepHandlers[stepExpr.type](stepExpr.qualifier, doc);
 }

--- a/packages/webdoc-model/src/query/variant.js
+++ b/packages/webdoc-model/src/query/variant.js
@@ -20,6 +20,10 @@ function condition(conditionClause: VariantCondition, doc: Doc): boolean {
 
 // Evaluates all variant conditionsa and returns whether the doc passes them.
 export function variant(variantExpr: VariantExpr, doc: Doc): boolean {
+  if (!variantExpr) {
+    return true;
+  }
+
   for (let i = 0, j = variantExpr.conditions.length; i < j; i++) {
     if (!condition(variantExpr.conditions[i], doc)) {
       return false;

--- a/packages/webdoc-template-library/package.json
+++ b/packages/webdoc-template-library/package.json
@@ -43,7 +43,8 @@
     "git-branch": "2.0.1",
     "missionlog": "1.6.0",
     "parse-github-url": "1.0.2",
-    "lodash": "^4.17.15"
+    "lodash": "^4.17.15",
+    "nanoid": "~3.1.16"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/packages/webdoc-template-library/src/SymbolLinks.js
+++ b/packages/webdoc-template-library/src/SymbolLinks.js
@@ -442,7 +442,7 @@ const getAncestorLinks = (doc: Doc, cssClass: string): string[] => {
  *
  * @object
  */
- const SymbolLinks = {
+export const SymbolLinks = {
   STANDALONE_DOCS,
   pathToUrl,
   urlToPath,

--- a/packages/webdoc-template-library/src/SymbolLinks.js
+++ b/packages/webdoc-template-library/src/SymbolLinks.js
@@ -442,7 +442,7 @@ const getAncestorLinks = (doc: Doc, cssClass: string): string[] => {
  *
  * @object
  */
-export const SymbolLinks = {
+ const SymbolLinks = {
   STANDALONE_DOCS,
   pathToUrl,
   urlToPath,

--- a/packages/webdoc-template-library/src/SymbolLinks.js
+++ b/packages/webdoc-template-library/src/SymbolLinks.js
@@ -1,7 +1,7 @@
 // @flow
-import {templateLogger} from "./Logger";
 import type {Doc} from "@webdoc/types";
 import {isDataType} from "@webdoc/model";
+import {templateLogger} from "./Logger";
 
 // TODO: Replace catharsis with a in-built @webdoc/data-type-parser
 const catharsis = require("catharsis");

--- a/packages/webdoc-template-library/src/TemplateRenderer.js
+++ b/packages/webdoc-template-library/src/TemplateRenderer.js
@@ -18,6 +18,8 @@ import {SymbolLinks} from "./SymbolLinks";
 import fs from "fs";
 import path from "path";
 
+let printedDefaultLinker = false;
+
 /**
  * The template renderer uses lodash to parse .tmpl template files and renders HTML content. A
  * template file contains {@code <?js js>} delimiters containing JavaScript code to control
@@ -106,7 +108,16 @@ export class TemplateRenderer {
     return this;
   }
 
-  //linkTo = SymbolLinks.linkTo
+  linkTo(...args) {
+    if (!printedDefaultLinker) {
+      console.warn("The default linker is the deprecated SymbolLinks API. " +
+        "Upgrade to the LinkerPlugin!");
+      printedDefaultLinker = true;
+      this.linkTo = SymbolLinks.linkTo;
+    }
+
+    return SymbolLinks.linkTo(...args);
+  }
 
   find(spec: any) {
     return this.docDatabase(spec).get();

--- a/packages/webdoc-template-library/src/TemplateRenderer.js
+++ b/packages/webdoc-template-library/src/TemplateRenderer.js
@@ -106,7 +106,7 @@ export class TemplateRenderer {
     return this;
   }
 
-  linkTo = SymbolLinks.linkTo
+  //linkTo = SymbolLinks.linkTo
 
   find(spec: any) {
     return this.docDatabase(spec).get();

--- a/packages/webdoc-template-library/src/TemplateRenderer.js
+++ b/packages/webdoc-template-library/src/TemplateRenderer.js
@@ -13,8 +13,8 @@ import type {
   RootDoc,
   TypedefDoc,
 } from "@webdoc/types";
-import {SymbolLinks} from "./SymbolLinks";
 import {tag, templateLogger} from "./Logger";
+import {SymbolLinks} from "./SymbolLinks";
 import fs from "fs";
 import path from "path";
 
@@ -73,6 +73,10 @@ export class TemplateRenderer {
     return this;
   }
 
+  getPlugin<T>(pluginName: string): T {
+    return this.plugins[pluginName];
+  }
+
   /**
    * Install a plugin to this renderer. It can be accessed at `renderer.plugins[name]`.
    *
@@ -88,10 +92,16 @@ export class TemplateRenderer {
       return this;
     }
 
-    this.plugins[name] = this.plugins[name] || {};
+    if (plugin.bindingPolicy === "complete") {
+      this.plugins[name] = plugin;
 
-    Object.assign(this.plugins[name], plugin);
-    this.plugins[name].renderer = this;
+      plugin.onBind(this);
+    } else {
+      this.plugins[name] = this.plugins[name] || {};
+
+      Object.assign(this.plugins[name], plugin);
+      this.plugins[name].renderer = this;
+    }
 
     return this;
   }

--- a/packages/webdoc-template-library/src/index.js
+++ b/packages/webdoc-template-library/src/index.js
@@ -2,6 +2,5 @@ export * from "./Logger";
 export * from "./TemplatePipeline";
 export * from "./TemplateRenderer";
 export * from "./SymbolLinks";
-export * from "./template-plugins/RelationsPlugin";
-export * from "./template-plugins/RepositoryPlugin";
+export * from "./template-plugins";
 export * from "./pipeline-elements";

--- a/packages/webdoc-template-library/src/pipeline-elements/TemplateTagsResolver.js
+++ b/packages/webdoc-template-library/src/pipeline-elements/TemplateTagsResolver.js
@@ -1,7 +1,6 @@
 // @flow
 
-import {SymbolLinks} from "../SymbolLinks";
-import type {TemplatePipelineElement} from "../TemplatePipeline";
+import type {TemplatePipeline, TemplatePipelineElement} from "../TemplatePipeline";
 
 const LINK_PATTERN = /{@link ([^|\s}]*)([\s|])?([^}]*)}/g;
 
@@ -20,6 +19,10 @@ export class TemplateTagsResolver implements TemplatePipelineElement<{}> {
    */
   constructor(options?: { linkClass?: string } = {}) {
     this.linkClass = options.linkClass;
+  }
+
+  attachTo(pipeline: TemplatePipeline) {
+    this.renderer = pipeline.renderer;
   }
 
   run(input: string, pipelineData: any): string {
@@ -44,7 +47,7 @@ export class TemplateTagsResolver implements TemplatePipelineElement<{}> {
         replaced = `<a ${this.linkClass ? "class=\"" + this.linkClass + "\"" : ""}` +
         `href="${link}">${linkText}</a>`;
       } else {
-        replaced = SymbolLinks.linkTo(link, linkText);
+        replaced = this.renderer.linkTo(link, linkText);
       }
 
       const startIndex = linkTextMatch ? linkTextMatch.index : linkMatch.index;

--- a/packages/webdoc-template-library/src/template-plugins/LinkerPlugin.js
+++ b/packages/webdoc-template-library/src/template-plugins/LinkerPlugin.js
@@ -1,0 +1,388 @@
+// @flow
+import type {Doc, DocType} from "@webdoc/types";
+import {RuntimePlugin} from "./RuntimePlugin";
+import {isDataType} from "@webdoc/model";
+import {templateLogger} from "./Logger";
+
+type LinkOptions = {
+  cssClass?: string,
+  fragmentId?: string,
+  linkMap?: Map<string, string>,
+  monospace?: boolean,
+  shortenName?: boolean
+};
+
+// TODO: Replace catharsis with a in-built @webdoc/data-type-parser
+const catharsis = require("catharsis");
+
+let LinkerPlugin;
+
+function LinkerPluginShell() {
+  /* -----------------------Helper Functions--------------------------------- */
+  function isComplexTypeExpression(expr) {
+    // record types, type unions, and type applications all count as "complex"
+    return /^{.+}$/.test(expr) || /^.+\|.+$/.test(expr) || /^.+<.+>$/.test(expr);
+  }
+  function hasUrlPrefix(text) {
+    return (/^(http|ftp)s?:\/\//).test(text);
+  }
+  function getShortName(docPath) {
+    const parts = docPath.split(/(.|#|~)/);
+    return parts[parts.length - 1];
+  }
+  function stringifyType(parsedType, cssClass, stringifyLinkMap) {
+    return require("catharsis").stringify(parsedType, {
+      cssClass: cssClass,
+      htmlSafe: true,
+      links: stringifyLinkMap,
+    });
+  }
+  function parseType(longname) {
+    let err;
+
+    try {
+      return catharsis.parse(longname, {jsdoc: true});
+    } catch (e) {
+      err = new Error(`unable to parse ${longname}: ${e.message}`);
+      templateLogger.error(err);
+
+      return longname;
+    }
+  }
+  function mapToLinks(documentRegistry) {
+    const keys = documentRegistry.keys();
+    const object = {};
+
+    keys.forEach((key) => {
+      object[key] = documentRegistry.get(key).uri;
+    });
+
+    return object;
+  }
+  /* -------------------------------------------------------------- */
+
+  type LinkerDocumentRecord = {
+    uri?: string,
+  };
+
+  type LinkerFileRecord = {
+    uriFragments: Set<string>,
+    uri?: string,
+  };
+
+  class LinkerPluginImpl extends RuntimePlugin {
+    /**
+     * The documents that are rendered into standalone files. By default, only
+     * classes, namespaes, interfaces, mixins, packages, and tutorials are
+     * standalone.
+     */
+    standaloneDocTypes: Array<DocType> = [
+      "ClassDoc",
+      "NSDoc",
+      "InterfaceDoc",
+      "MixinDoc",
+      "PackageDoc",
+      "TutorialDoc",
+    ];
+
+    /**
+     * This holds all the linker's data on each document, mapped from the document
+     * IDs.
+     * @protected
+     */
+    documentRegistry = new Map<string, LinkerDocumentRecord>();
+
+    /**
+     * This holds all the linker's data on each output file, mapping each URI lowercased.
+     * @protected
+     */
+    fileRegistry = new Map<string, LinkerFileRecord>();
+
+    /**
+     * Returns the linker's record on a specific document, creating a new one if one does not exist
+     * already.
+     *
+     * @param {string} id - The ID of the document whose record is requested.
+     * @return {LinkerDocumentRecord} All the data this linker has on the document.
+     */
+    getDocumentRecord(id: string): LinkerDocumentRecord {
+      const recordHit = this.documentRegistry.get(id);
+
+      if (!recordHit) {
+        const record: LinkerDocumentRecord = {};
+
+        this.documentRegistry.set(id, record);
+
+        return record;
+      }
+
+      return recordHit;
+    }
+
+    /**
+     * Returns the linker's record on a specific output file, creating a new one if
+     * one does not exist already.
+     *
+     * @param {string} uri - The URI for the output file.
+     * @return {LinkerFileRecord} All the data this linker has on the output file.
+     */
+    getFileRecord(uri: string): LinkerFileRecord {
+      const recordHit = this.fileRecord.get(uri.toLowerCase());
+
+      if (!recordHit) {
+        const record: LinkerFileRecord = {
+          uriFragments: new Set<string>(),
+        };
+
+        this.fileRegistry.set(uri, record);
+
+        return record;
+      }
+
+      return recordHit;
+    }
+
+    /**
+     * Build an HTML link to the symbol with the specified {@code docPath}. If the doc-path is not
+     * associated with a URL, this method simply returns the link text, if provided, or the doc-path
+     * itself.
+     *
+     * The {@code docPath} parameter can also contain a URL rather than a symbol's longname.
+     *
+     * This method supports type applications that can contain one or more types, such as
+     * {@code Array.<MyClass>} or {@code Array.<(MyClass|YourClass)>}. In these examples, the method
+     * attempts to replace `Array`, `MyClass`, and `YourClass` with links to the appropriate types.
+     * The link text is ignored for type applications.
+     *
+     * @param {string} docPath - The longname (or URL) that is the target of the link.
+     * @param {string} linkText - The text to display for the link, or `longname` if no text is
+     * provided.
+     * @param {Object} options - Options for building the link.
+     * @param {string} options.cssClass - The CSS class (or classes) to include in the link's `<a>`
+     * tag.
+     * @param {string} options.fragmentId - The fragment identifier (for example, `name` in
+     * `foo.html#name`) to append to the link target.
+     * @param {string} options.linkMap - The link map in which to look up the longname.
+     * @param {boolean} options.monospace - Indicates whether to display the link text in a monospace
+     * font.
+     * @param {boolean} options.shortenName - Indicates whether to extract the short name from the
+     * longname and display the short name in the link text. Ignored if `linkText` is specified.
+     * @return {string} the HTML link, or the link text if the link is not available.
+     */
+    linkTo(docPath: string, linkText: string = docPath, options: LinkOptions) {
+      if (!docPath) {
+        return "";
+      }
+      if (isDataType(docPath)) {
+        let link = docPath.template;
+
+        for (let i = 1; i < docPath.length; i++) {
+          link = link.replace(`%${i}`, this.linkTo(docPath[i], docPath[i], options));
+        }
+
+        return link;
+      } else if (typeof docPath !== "string") {
+        docPath = docPath.path;// BaseDoc
+      }
+
+      if (linkText && typeof linkText !== "string") {
+        linkText = linkText.path;
+      }
+
+      const classString = options.cssClass ? ` class="${options.cssClass}"` : "";
+      let fileUrl;
+      const fragmentString = options.fragmentId ? "#" + options.fragmentId : "";
+      let text;
+
+      let parsedType;
+
+      // handle cases like:
+      // @see <http://example.org>
+      // @see http://example.org
+      const stripped = docPath ? docPath.replace(/^<|>$/g, "") : "";
+      if (hasUrlPrefix(stripped)) {
+        fileUrl = stripped;
+        text = linkText || stripped;
+      } // eslint-disable-line brace-style
+      // handle complex type expressions that may require multiple links
+      // (but skip anything that looks like an inline tag or HTML tag)
+      else if (docPath && isComplexTypeExpression(docPath) && /\{@.+\}/.test(docPath) === false &&
+            /^<[\s\S]+>/.test(docPath) === false) {
+        parsedType = parseType(docPath);
+
+        // Optimize Object.fromEntires, it's ugly
+        return stringifyType(parsedType, options.cssClass, mapToLinks(this.documentRegistry));
+      } else {
+        fileUrl = options.linkMap.has(docPath) ? options.linkMap.get(docPath) : "";
+        text = linkText || (options.shortenName ? getShortName(docPath) : docPath);
+      }
+
+      text = options.monospace ? `<code>${text}</code>` : text;
+
+      if (!fileUrl) {
+        return text;
+      } else {
+        return `<a href="${encodeURI(fileUrl + fragmentString)}"${classString}>${text}</a>`;
+      }
+    }
+
+    /**
+     * @override
+     */
+    getShell() {
+      return LinkerPluginShell;
+    }
+
+    /**
+     * Returns the URI pointing to the document's output file. An unique URI is created, if one
+     * wasn't already.
+     *
+     * @param {Doc | string} doc
+     * @return {string}
+     */
+    getURI(doc: Doc | string): string {
+      if (typeof doc === "object") {
+        doc = doc.id;
+      }
+
+      const record = this.getDocumentRecord(doc);
+      let uri = record.uri;
+
+      if (!uri) {
+        uri = this.generateURI(doc);
+        record.uri = uri;
+      }
+
+      return uri;
+    }
+
+    /**
+     * Convert a string to a unique filename, including an extension.
+     *
+     * Filenames are cached to ensure that they are used only once. For example, if the same
+     * string is passed in twice, two different filenames will be returned.
+     *
+     * Also, filenames are not considered unique if they are capitalized differently but are
+     * otherwise identical.
+     *
+     * @private
+     * @param {string} canonicalPath - The canonical
+     * @return {string} The filename to use for the string.
+     */
+    generateBaseURI(canonicalPath: string): string {
+      let seedURI = (canonicalPath || "")
+        // use - instead of : in namespace prefixes
+        // replace characters that can cause problems on some filesystems
+        .replace(/[\\/?*:|'"<>]/g, "_")
+        // use - instead of ~ to denote 'inner'
+        .replace(/~/g, "-")
+        // use _ instead of # to denote 'instance'
+        .replace(/#/g, "_")
+        // use _ instead of / (for example, in module names)
+        .replace(/\//g, "_")
+        // remove the variation, if any
+        .replace(/\([\s\S]*\)$/, "")
+        // make sure we don't create hidden files, or files whose names start with a dash
+        .replace(/^[.-]/, "");
+
+      // in case we've now stripped the entire basename (uncommon, but possible):
+      seedURI = seedURI.length ? seedURI : "_";
+      seedURI += ".html";
+
+      let probeURI = seedURI;
+      let probeKey = seedURI.toLowerCase();
+      let nonUnique = true;
+
+      // Don't allow filenames to begin with an underscore
+      if (!seedURI.length || seedURI[0] === "_") {
+        probeURI = `-${seedURI}`;
+        probeKey = probeURI.toLowerCase();
+      }
+
+      // Append enough underscores to make the filename unique
+      while (nonUnique) {
+        if (this.fileRegistry.has(probeKey)) {
+          probeURI += "_";
+          probeKey += "_";
+        } else {
+          nonUnique = false;
+        }
+      }
+
+      return probeURI;
+    }
+
+    /**
+     * Generates a unique ID for a DOM element (unique within each HTML file)
+     *
+     * @private
+     * @param {string} fileName
+     * @param {string} id
+     * @param {Set<string>} usedIDs
+     * @return {string}
+     */
+    generateURIFragment(fileName: string, id: string, usedIDs: Set<string>): string {
+      let key;
+      let nonUnique = true;
+
+      key = id.toLowerCase();
+      // HTML5 IDs cannot contain whitespace characters
+      id = id.replace(/\s/g, "");
+
+      // append enough underscores to make the identifier unique
+      while (nonUnique) {
+        if (usedIDs.has(key)) {
+          id += "_";
+          key = id.toLowerCase();
+        } else {
+          nonUnique = false;
+        }
+      }
+
+      usedIDs.add(key);
+
+      return id;
+    }
+
+    /**
+     * Create a URL that points to the generated documentation for the doc.
+     *
+     * If a doc corresponds to an output file (for example, if the doc represents a class), the
+     * URL will consist of a filename.
+     *
+     * If a doc corresponds to a smaller portion of an output file (for example, if the doc
+     * represents a method), the URL will consist of a filename and a fragment ID.
+     *
+     * @memberof SymbolLinks
+     * @param {Doc} doc - The doc that will be used to create the URL.
+     * @return {string} The URL to the generated documentation for the doc.
+     */
+    generateURI(doc: Doc) {
+      let baseURI: string;
+      let fragment: string;
+      const docPath = doc.path;
+      const {standaloneDocTypes} = this;
+
+      // the doc gets its own HTML file
+      if (standaloneDocTypes.includes(doc.type)) {
+        baseURI = this.generateBaseURI(docPath);
+      } else { // inside another HTML file
+        baseURI = this.getURI(doc.parent);
+        fragment = this.generateURIFragment(
+          baseURI,
+          doc.name,
+          this.getFileRecord(baseURI).uriFragments,
+        );
+      }
+
+      return `${encodeURI(baseURI)}${fragment ? "#" + fragment : ""}`;
+    }
+  }
+
+  LinkerPlugin = LinkerPluginImpl;
+
+  return LinkerPlugin;
+}
+
+export {LinkerPlugin};
+export {LinkerPluginShell};

--- a/packages/webdoc-template-library/src/template-plugins/LinkerPlugin.js
+++ b/packages/webdoc-template-library/src/template-plugins/LinkerPlugin.js
@@ -29,7 +29,7 @@ function LinkerPluginShell() {
   // TODO: Replace catharsis with a in-built @webdoc/data-type-parser
   const catharsis = require("catharsis");
   const {query} = require("@webdoc/model");
-  const {Plugin} = require("./Plugin");
+  const {MixinPlugin} = require("./MixinPlugin");
 
   /* -----------------------Helper Functions--------------------------------- */
   function isComplexTypeExpression(expr) {
@@ -77,7 +77,7 @@ function LinkerPluginShell() {
   /**
    * @class LinkerPlugin
    */
-  class LinkerPluginImpl extends Plugin {
+  class LinkerPluginImpl extends MixinPlugin {
     /**
      * The documents that are rendered into standalone files. By default, only
      * classes, namespaes, interfaces, mixins, packages, and tutorials are
@@ -181,7 +181,7 @@ function LinkerPluginShell() {
      * longname and display the short name in the link text. Ignored if `linkText` is specified.
      * @return {string} the HTML link, or the link text if the link is not available.
      */
-    linkTo(docPath: string, linkText: string = docPath, options: LinkOptions) {
+    linkTo(docPath: string, linkText: string = docPath, options: LinkOptions = {}) {
       if (!docPath) {
         return "";
       }
@@ -231,6 +231,7 @@ function LinkerPluginShell() {
         const doc = query(docPath, this.renderer.docTree)[0];
 
         if (!doc) {
+          console.log("QUERY RESULT: " + docPath + " -> " + (doc ? doc.path : "undefined"))
           return text;
         }
 
@@ -244,8 +245,6 @@ function LinkerPluginShell() {
       }
 
       text = options.monospace ? `<code>${text}</code>` : text;
-
-      console.log(docPath, fileUrl)
 
       if (!fileUrl) {
         return text;
@@ -448,6 +447,8 @@ function LinkerPluginShell() {
       // the doc gets its own HTML file
       if (standaloneDocTypes.includes(doc.type)) {
         baseURI = this.generateBaseURI(docPath);
+
+        this.getFileRecord(baseURI);
       } else { // inside another HTML file
         baseURI = doc.parent.type !== "RootDoc" ? this.getURI(doc.parent) : "global.html";
         fragment = this.generateURIFragment(

--- a/packages/webdoc-template-library/src/template-plugins/LinkerPlugin.js
+++ b/packages/webdoc-template-library/src/template-plugins/LinkerPlugin.js
@@ -235,7 +235,7 @@ function LinkerPluginShell() {
         const doc = query(docPath, this.renderer.docTree)[0];
 
         if (!doc) {
-          return text;
+          return linkText || docPath;
         }
 
         const rec = this.documentRegistry.get(doc.id);

--- a/packages/webdoc-template-library/src/template-plugins/LinkerPlugin.js
+++ b/packages/webdoc-template-library/src/template-plugins/LinkerPlugin.js
@@ -118,6 +118,10 @@ function LinkerPluginShell() {
      * @return {LinkerDocumentRecord} All the data this linker has on the document.
      */
     getDocumentRecord(id: string): LinkerDocumentRecord {
+      if (typeof id !== "string") {
+        throw new Error("The id must be a valid string!");
+      }
+
       const recordHit = this.documentRegistry.get(id);
 
       if (!recordHit) {
@@ -231,11 +235,12 @@ function LinkerPluginShell() {
         const doc = query(docPath, this.renderer.docTree)[0];
 
         if (!doc) {
-          console.log("QUERY RESULT: " + docPath + " -> " + (doc ? doc.path : "undefined"))
           return text;
         }
 
-        fileUrl = this.getDocumentRecord(doc).uri || this.getURI(doc);
+        const rec = this.documentRegistry.get(doc.id);
+
+        fileUrl = rec ? rec.uri : this.getURI(doc);
 
         // Cache this query
         if (fileUrl) {

--- a/packages/webdoc-template-library/src/template-plugins/MixinPlugin.js
+++ b/packages/webdoc-template-library/src/template-plugins/MixinPlugin.js
@@ -1,0 +1,34 @@
+// @flow
+
+import {Plugin} from "./Plugin";
+import type {TemplateRenderer} from "../TemplateRenderer";
+
+export type MixinPolicy = "enabled" | "disabled";
+
+/**
+ * @abstract
+ */
+export class MixinPlugin extends Plugin {
+  constructor() {
+    super();
+
+    this.mixinPolicy = "enabled";
+  }
+
+  onBind(renderer: TemplateRenderer) {
+    super.onBind(renderer);
+
+    if (this.mixinPolicy === "enabled") {
+      Object.assign(renderer, this.getMixin());
+    }
+  }
+
+  /**
+   * This returns the mixin this plugin exposes on the renderer object.
+   *
+   * @return {Object}
+   */
+  getMixin() {
+    return {};
+  }
+}

--- a/packages/webdoc-template-library/src/template-plugins/Plugin.js
+++ b/packages/webdoc-template-library/src/template-plugins/Plugin.js
@@ -5,7 +5,7 @@ export type BindingPolicy = "partial" | "complete";
 /**
  * @abstract
  */
-export class RuntimePlugin {
+export class Plugin {
   constructor() {
     this.bindingPolicy = "complete";
     this.renderer = null;

--- a/packages/webdoc-template-library/src/template-plugins/RuntimePlugin.js
+++ b/packages/webdoc-template-library/src/template-plugins/RuntimePlugin.js
@@ -1,0 +1,34 @@
+import type {TemplateRenderer} from "../TemplateRenderer";
+
+export type BindingPolicy = "partial" | "complete";
+
+/**
+ * @abstract
+ */
+export class RuntimePlugin {
+  constructor() {
+    this.bindingPolicy = "complete";
+    this.renderer = null;
+  }
+
+  onBind(renderer: TemplateRenderer) {
+    this.renderer = renderer;
+  }
+
+  /**
+   * This method returns the plugin's "shell". The shell is a function that wraps the plugin's
+   * class and can be stringified to send the plugin to another runtime environment (worker thread
+   * or child process).
+   *
+   * Invoking the shell should return the plugin class.
+   *
+   * @example
+   * ```
+   * // Creates a new instance of the plugin "plugin"
+   * const plugin2 = new (plugin.getShell()())
+   * ```
+   */
+  getShell() {
+    throw new Error("Not Implemented: Plugin did not provide a shell!");
+  }
+}

--- a/packages/webdoc-template-library/src/template-plugins/index.js
+++ b/packages/webdoc-template-library/src/template-plugins/index.js
@@ -1,0 +1,5 @@
+export * from "./LinkerPlugin";
+export * from "./MixinPlugin";
+export * from "./Plugin";
+export * from "./RelationsPlugin";
+export * from "./RepositoryPlugin";

--- a/packages/webdoc-template-library/test/pipeline-elements/TemplateTagsResolver.js
+++ b/packages/webdoc-template-library/test/pipeline-elements/TemplateTagsResolver.js
@@ -1,9 +1,15 @@
+const {LinkerPlugin} = require("../../lib/template-plugins/LinkerPlugin");
 const {TemplateTagsResolver} = require("../../lib/pipeline-elements/TemplateTagsResolver");
+const {TemplateRenderer} = require("../../lib/TemplateRenderer");
 
 const expect = require("chai").expect;
 
 describe("@webdoc/template-library.TemplateTagsResolver", function() {
   const mockTagsResolver = new TemplateTagsResolver();
+  const mockTemplateRenderer = new TemplateRenderer();
+
+  mockTemplateRenderer.installPlugin("linker", LinkerPlugin);
+  mockTagsResolver.attachTo({ renderer: mockTemplateRenderer });
 
   it("{@link <DOC_PATH>}", function() {
     expect(mockTagsResolver.runLink("--{@link <DOC_PATH>}--"))


### PR DESCRIPTION
Fixes #42

I DID IT! The `LinkerPlugin` API replaces the (deprecated) `SymbolLinks` API. It uses a mapping between the document IDs (rather than canonical paths) to the URI information. Then, a `queryCache` is used to cache DPL queries to links.