### PR TITLE
Better regex for @property value parsing to capture non-word, non-whitespace characters

### DIFF
--- a/packages/webdoc-parser/src/tag-parsers/parseProperty.js
+++ b/packages/webdoc-parser/src/tag-parsers/parseProperty.js
@@ -21,7 +21,8 @@ export function extractDataValue(value: string): any {
     return /'([^'])*'/.exec(value);
   }
 
-  return /(\w)+/.exec(value);
+  // Match everything until a whitespace
+  return /([^ ])+/.exec(value);
 }
 
 // Extract simpleName & defaultValue when passing simpleName=defaultValue

--- a/packages/webdoc-parser/test/tag-parsers/parseProperty.js
+++ b/packages/webdoc-parser/test/tag-parsers/parseProperty.js
@@ -61,6 +61,17 @@ describe("@webdoc/parser.parseProperty", function() {
     expect(propertyDoc.description).to.equal("<description>");
   });
 
+  it("@property {DataType} propertyName=-numberDefaultValue - <description>", function() {
+    const doc = {};
+
+    parseProperty("{DataType} propertyName=-numberDefaultValue - <description>", doc);
+
+    const propertyDoc = doc.members[0];
+
+    expect(propertyDoc.constant).to.equal(true);
+    expect(propertyDoc.dataValue).to.equal("-numberDefaultValue");
+    expect(propertyDoc.description).to.equal("<description>");
+  });
 
   it("@property {DataType}[propertyName] <description>", function() {
     const doc = {};


### PR DESCRIPTION
Fixes #43.

Use a different regex that matches non-whitespace characters instead of only word characters.