### PR TITLE
[Fix]: Query cache should link around cached URI

### DIFF
--- a/packages/webdoc-template-library/src/template-plugins/LinkerPlugin.js
+++ b/packages/webdoc-template-library/src/template-plugins/LinkerPlugin.js
@@ -190,7 +190,7 @@ function LinkerPluginShell() {
         return "";
       }
       if (this.queryCache.has(docPath)) {
-        return `<a href=${encodeURI(this.queryCache.get(docPath))}>${linkText}</a>`;
+        return `<a href=${encodeURI(this.queryCache.get(docPath) || "")}>${linkText}</a>`;
       }
       if (isDataType(docPath)) {
         let link = docPath.template;

--- a/packages/webdoc-template-library/src/template-plugins/LinkerPlugin.js
+++ b/packages/webdoc-template-library/src/template-plugins/LinkerPlugin.js
@@ -190,7 +190,7 @@ function LinkerPluginShell() {
         return "";
       }
       if (this.queryCache.has(docPath)) {
-        return this.queryCache.get(docPath);
+        return `<a href=${encodeURI(this.queryCache.get(docPath))}>${linkText}</a>`;
       }
       if (isDataType(docPath)) {
         let link = docPath.template;


### PR DESCRIPTION
I wonder why this didn't affect the default template 🤔. Found when testing pixi-webdoc-template with the linker plugin.